### PR TITLE
[Foundation] AuthClient 인터페이스와 구현 분리

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ opt_in_rules:
 disabled_rules:
   - trailing_whitespace
   - line_length
+  - switch_case_alignment
 
 excluded:
   - Tuist

--- a/Clients/AuthClient/Interface/Sources/AuthClient.swift
+++ b/Clients/AuthClient/Interface/Sources/AuthClient.swift
@@ -1,0 +1,11 @@
+import Models
+
+public struct AuthClient: Sendable {
+    public var login: @Sendable (LoginCredentials) async throws -> AuthSession
+    public var logout: @Sendable () async throws -> Void
+    
+    public init(login: @escaping @Sendable (LoginCredentials) async throws -> AuthSession, logout: @escaping @Sendable () async throws -> Void) {
+        self.login = login
+        self.logout = logout
+    }
+}

--- a/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
+++ b/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
@@ -5,23 +5,21 @@
 //  Created by 송지혁 on 4/27/26.
 //
 
-import ComposableArchitecture
+import Dependencies
 
-private enum AuthClientKey: DependencyKey {
-    static let liveValue = AuthClient(
-        login: { _ in
-            fatalError("AuthClient.liveValue is not configured")
-        },
-        logout: {
-            fatalError("AuthClient.liveValue is not configured")
-        }
-    )
+extension AuthClient: DependencyKey {
+    public static let liveValue = AuthClient(login: unimplemented("AuthClient.login"),
+                                             logout: unimplemented("AuthClient.logout"))
+    
+    public static let testValue = AuthClient(login: unimplemented("AuthClient.login"),
+                                             logout: unimplemented("AuthClient.logout"))
+
 }
 
 
-public extension DependencyValues {
-    var authClient: AuthClient {
-        get { self[AuthClientKey.self] }
-        set { self[AuthClientKey.self] = newValue }
+extension DependencyValues {
+    public var authClient: AuthClient {
+        get { self[AuthClient.self] }
+        set { self[AuthClient.self] = newValue }
     }
 }

--- a/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
+++ b/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
@@ -16,7 +16,6 @@ extension AuthClient: DependencyKey {
 
 }
 
-
 extension DependencyValues {
     public var authClient: AuthClient {
         get { self[AuthClient.self] }

--- a/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
+++ b/Clients/AuthClient/Interface/Sources/AuthClientKey.swift
@@ -1,0 +1,27 @@
+//
+//  AuthClientKey.swift
+//  ClientAuth
+//
+//  Created by 송지혁 on 4/27/26.
+//
+
+import ComposableArchitecture
+
+private enum AuthClientKey: DependencyKey {
+    static let liveValue = AuthClient(
+        login: { _ in
+            fatalError("AuthClient.liveValue is not configured")
+        },
+        logout: {
+            fatalError("AuthClient.liveValue is not configured")
+        }
+    )
+}
+
+
+public extension DependencyValues {
+    var authClient: AuthClient {
+        get { self[AuthClientKey.self] }
+        set { self[AuthClientKey.self] = newValue }
+    }
+}

--- a/Clients/AuthClient/Live/Sources/AuthClient+Live.swift
+++ b/Clients/AuthClient/Live/Sources/AuthClient+Live.swift
@@ -7,7 +7,7 @@
 import ClientAuth
 
 public extension AuthClient {
-    static let live = AuthClient { credentials in
+    static let live = AuthClient { _ in
         fatalError("login live implementation is not implemented yet")
     } logout: {
         fatalError("logout live implementation is not implemented yet")

--- a/Clients/AuthClient/Live/Sources/AuthClient+Live.swift
+++ b/Clients/AuthClient/Live/Sources/AuthClient+Live.swift
@@ -1,0 +1,16 @@
+//
+//  AuthClient+Live.swift
+//  ClientAuth
+//
+//  Created by 송지혁 on 4/27/26.
+//
+import ClientAuth
+
+public extension AuthClient {
+    static let live = AuthClient { credentials in
+        fatalError("login live implementation is not implemented yet")
+    } logout: {
+        fatalError("logout live implementation is not implemented yet")
+    }
+
+}

--- a/Clients/AuthClient/Test/Sources/AuthClient+Test.swift
+++ b/Clients/AuthClient/Test/Sources/AuthClient+Test.swift
@@ -9,7 +9,7 @@ import ClientAuth
 import Models
 
 public extension AuthClient {
-    static let mockSuccess = AuthClient { credentials in
+    static let mockSuccess = AuthClient { _ in
         AuthSession()
     } logout: {
         

--- a/Clients/AuthClient/Test/Sources/AuthClient+Test.swift
+++ b/Clients/AuthClient/Test/Sources/AuthClient+Test.swift
@@ -1,0 +1,18 @@
+//
+//  AuthClient+Test.swift
+//  ClientAuth
+//
+//  Created by 송지혁 on 4/27/26.
+//
+
+import ClientAuth
+import Models
+
+public extension AuthClient {
+    static let mockSuccess = AuthClient { credentials in
+        AuthSession()
+    } logout: {
+        
+    }
+    
+}

--- a/M_GAME/Sources/AppFeature.swift
+++ b/M_GAME/Sources/AppFeature.swift
@@ -20,7 +20,7 @@ struct AppFeature {
     }
     
     var body: some ReducerOf<Self> {
-        Reduce { state, action in
+        Reduce { _, action in
             switch action {
                 default: return .none
             }

--- a/M_GAME/Sources/AppFeature.swift
+++ b/M_GAME/Sources/AppFeature.swift
@@ -1,0 +1,29 @@
+//
+//  AppFeature.swift
+//  M_GAME
+//
+//  Created by 송지혁 on 4/28/26.
+//
+
+import ComposableArchitecture
+import FeatureLogin
+
+@Reducer
+struct AppFeature {
+    @ObservableState
+    struct State {
+        
+    }
+    
+    enum Action {
+        
+    }
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+                default: return .none
+            }
+        }
+    }
+}

--- a/M_GAME/Sources/ContentView.swift
+++ b/M_GAME/Sources/ContentView.swift
@@ -2,7 +2,8 @@ import ComposableArchitecture
 import SwiftUI
 
 struct ContentView: View {
-
+    let store: StoreOf<AppFeature>
+    
     var body: some View {
         Text("Hello, World!")
             .padding()
@@ -10,5 +11,8 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    ContentView(store: Store(initialState: AppFeature.State(),
+                             reducer: { AppFeature() },
+                             withDependencies: { $0.authClient = .mockSuccess })
+    )
 }

--- a/M_GAME/Sources/ContentView.swift
+++ b/M_GAME/Sources/ContentView.swift
@@ -13,6 +13,6 @@ struct ContentView: View {
 #Preview {
     ContentView(store: Store(initialState: AppFeature.State(),
                              reducer: { AppFeature() },
-                             withDependencies: { $0.authClient = .mockSuccess })
+                             withDependencies: { $0.authClient = .live })
     )
 }

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,5 +1,4 @@
 import ClientAuthLive
-import ClientAuthTest
 import ComposableArchitecture
 import SwiftUI
 

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,10 +1,19 @@
+import ClientAuthLive
+import ClientAuthTest
+import ComposableArchitecture
 import SwiftUI
 
 @main
 struct MGAMEApp: App {
+    let store = Store(initialState: AppFeature.State()) {
+        AppFeature()
+    } withDependencies: {
+        $0.authClient = .live
+    }
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(store: store)
         }
     }
 }

--- a/Models/Sources/Domain/AuthSession.swift
+++ b/Models/Sources/Domain/AuthSession.swift
@@ -1,0 +1,10 @@
+//
+//  AuthSession.swift
+//  Models
+//
+//  Created by 송지혁 on 4/27/26.
+//
+
+public struct AuthSession {
+    public init() { }
+}

--- a/Models/Sources/Domain/LoginCredentials.swift
+++ b/Models/Sources/Domain/LoginCredentials.swift
@@ -1,0 +1,10 @@
+//
+//  LoginCredentials.swift
+//  Models
+//
+//  Created by 송지혁 on 4/27/26.
+//
+
+public struct LoginCredentials {
+    
+}

--- a/Project.swift
+++ b/Project.swift
@@ -14,8 +14,32 @@ let project = Project(
                     destinations: .iOS,
                     product: .framework,
                     bundleId: "io.tuist.MGAME.ClientAuth",
-                    sources: ["Clients/AuthClient/Sources/**"],
+                    sources: ["Clients/AuthClient/Interface/Sources/**"],
                     dependencies: [
+                        .target(name: "Models"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(name: "ClientAuthLive",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientAuthLive",
+                    sources: ["Clients/AuthClient/Live/Sources/**"],
+                    dependencies: [
+                        .target(name: "ClientAuth"),
+                        .target(name: "Models"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(name: "ClientAuthTest",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientAuthTest",
+                    sources: ["Clients/AuthClient/Test/Sources/**"],
+                    dependencies: [
+                        .target(name: "ClientAuth"),
                         .target(name: "Models"),
                         .external(name: "ComposableArchitecture")
                     ]

--- a/Project.swift
+++ b/Project.swift
@@ -153,7 +153,6 @@ let project = Project(
                 .target(name: "FeatureLobby"),
                 .target(name: "FeatureGame"),
                 .target(name: "ClientAuthLive"),
-                .target(name: "ClientAuthTest"),
                 .external(name: "ComposableArchitecture")
             ]
         ),

--- a/Project.swift
+++ b/Project.swift
@@ -152,6 +152,8 @@ let project = Project(
                 .target(name: "FeatureLogin"),
                 .target(name: "FeatureLobby"),
                 .target(name: "FeatureGame"),
+                .target(name: "ClientAuthLive"),
+                .target(name: "ClientAuthTest"),
                 .external(name: "ComposableArchitecture")
             ]
         ),

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,7 +21,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane ios ci
 ```
 
-CI: 빌드
+CI: 린트 + 빌드
 
 ----
 


### PR DESCRIPTION
## 관련 이슈

closes #4

## 변경 사항
### AuthClient 역할 변경

- `ClientAuth` 모듈의 `AuthClient`의 역할이 구체적인 로직 구현체가 아닌 인터페이스 역할을 하는 구조체로 변경되었습니다.
```swift
import Models

public struct AuthClient: Sendable {
    public var login: @Sendable (LoginCredentials) async throws -> AuthSession
    public var logout: @Sendable () async throws -> Void
    
    public init(login: @escaping @Sendable (LoginCredentials) async throws -> AuthSession, logout: @escaping @Sendable () async throws -> Void) {
        self.login = login
        self.logout = logout
    }
}


```

### Live/Test 구현 모듈 분리

- `AuthClient` 인터페이스를 기반으로 실제 실행 환경과 테스트 환경에서 사용할 구현체를 각각 분리했습니다.

```swift
// AuthClient+Live

import ClientAuth

public extension AuthClient {
    static let live = AuthClient { _ in
        fatalError("login live implementation is not implemented yet")
    } logout: {
        fatalError("logout live implementation is not implemented yet")
    }

}

```

```swift
// AuthClient+Test

import ClientAuth
import Models

public extension AuthClient {
    static let mockSuccess = AuthClient { _ in
        AuthSession()
    } logout: {
        
    }
    
}

```

## 기대 효과
- Feature 모듈이 `AuthClient`의 구체 구현이 아닌 인터페이스에만 의존하게 되어 모듈 간 결합도가 낮아졌습니다.
- `ClientAuthLive`와 `ClientAuthTest`를 분리하여 실행 환경과 테스트 환경의 경계를 명확히 나눴습니다.
- 


## 스크린샷

| Before | After |
|--------|-------|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/0af150ae-ae68-4e8e-9297-70cd5545ef06" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/9dd74d40-5f6e-4396-b741-b01c3cd9ee0c" /> |


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication framework infrastructure established with support for login and logout operations.

* **Chores**
  * Restructured build configuration to organize authentication modules.
  * Updated CI documentation to reflect linting in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->