### PR TITLE
[Foundation] ClientRoom 모듈 인터페이스/구현 모듈 분리

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,6 +7,7 @@ disabled_rules:
   - trailing_whitespace
   - line_length
   - switch_case_alignment
+  - trailing_newline
 
 excluded:
   - Tuist

--- a/Clients/RoomClient/Interface/Sources/RoomClient.swift
+++ b/Clients/RoomClient/Interface/Sources/RoomClient.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Models
+
+public struct RoomClient: Sendable {
+    public var createRoom: @Sendable (CreateRoomRequest) async throws -> Room
+    public var fetchRoom: @Sendable (UUID) async throws -> Room
+    public var updateRoom: @Sendable (UUID, UpdateRoomRequest) async throws -> Room
+    public var closeRoom: @Sendable (UUID) async throws -> Void
+    
+    public init(
+        createRoom: @escaping @Sendable (CreateRoomRequest) async throws -> Room,
+        fetchRoom: @escaping @Sendable (UUID) async throws -> Room,
+        updateRoom: @escaping @Sendable (UUID, UpdateRoomRequest) async throws -> Room,
+        closeRoom: @escaping @Sendable (UUID) async throws -> Void) {
+            
+        self.createRoom = createRoom
+        self.fetchRoom = fetchRoom
+        self.updateRoom = updateRoom
+        self.closeRoom = closeRoom
+    }
+}

--- a/Clients/RoomClient/Interface/Sources/RoomClientKey.swift
+++ b/Clients/RoomClient/Interface/Sources/RoomClientKey.swift
@@ -1,0 +1,31 @@
+//
+//  RoomClientKey.swift
+//  ClientRoom
+//
+//  Created by 송지혁 on 4/30/26.
+//
+
+import Dependencies
+
+extension RoomClient: DependencyKey {
+    public static let liveValue = RoomClient(
+        createRoom: unimplemented("RoomClient.create"),
+        fetchRoom: unimplemented("RoomClient.fetch"),
+        updateRoom: unimplemented("RoomClient.update"),
+        closeRoom: unimplemented("RoomClient.close")
+    )
+    
+    public static let testValue = RoomClient(
+        createRoom: unimplemented("RoomClient.create"),
+        fetchRoom: unimplemented("RoomClient.fetch"),
+        updateRoom: unimplemented("RoomClient.update"),
+        closeRoom: unimplemented("RoomClient.close")
+    )
+}
+
+extension DependencyValues {
+    public var roomClient: RoomClient {
+        get { self[RoomClient.self] }
+        set { self[RoomClient.self] = newValue }
+    }
+}

--- a/Clients/RoomClient/Live/Sources/RoomClient+Live.swift
+++ b/Clients/RoomClient/Live/Sources/RoomClient+Live.swift
@@ -1,0 +1,14 @@
+import ClientRoom
+
+public extension RoomClient {
+    static let live = RoomClient { _ in
+        fatalError("room live implementation is not implemented yet")
+    } fetchRoom: { _ in
+        fatalError("room live implementation is not implemented yet")
+    } updateRoom: { _, _ in
+        fatalError("room live implementation is not implemented yet")
+    } closeRoom: { _ in
+        fatalError("room live implementation is not implemented yet")
+    }
+}
+

--- a/Clients/RoomClient/Test/Sources/RoomClient+Test.swift
+++ b/Clients/RoomClient/Test/Sources/RoomClient+Test.swift
@@ -1,0 +1,12 @@
+import ClientRoom
+import Models
+
+public extension RoomClient {
+    static let mockSuccess = RoomClient { _ in
+        Room()
+    } fetchRoom: { _ in
+        Room()
+    } updateRoom: { _, _ in
+        Room()
+    } closeRoom: { _ in }
+}

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,4 +1,5 @@
 import ClientAuthLive
+import ClientRoomLive
 import ComposableArchitecture
 import SwiftUI
 
@@ -8,6 +9,7 @@ struct MGAMEApp: App {
         AppFeature()
     } withDependencies: {
         $0.authClient = .live
+        $0.roomClient = .live
     }
     
     var body: some Scene {

--- a/Models/Sources/Domain/Room/CreateRoomRequest.swift
+++ b/Models/Sources/Domain/Room/CreateRoomRequest.swift
@@ -1,0 +1,10 @@
+//
+//  CreateRoomRequest.swift
+//  Models
+//
+//  Created by 송지혁 on 4/30/26.
+//
+
+public struct CreateRoomRequest: Sendable {
+    public init() { }
+}

--- a/Models/Sources/Domain/Room/Room.swift
+++ b/Models/Sources/Domain/Room/Room.swift
@@ -5,4 +5,6 @@
 //  Created by 송지혁 on 4/26/26.
 //
 
-import Foundation
+public struct Room: Sendable {
+    public init() { }
+}

--- a/Models/Sources/Domain/Room/UpdateRoomRequest.swift
+++ b/Models/Sources/Domain/Room/UpdateRoomRequest.swift
@@ -1,0 +1,10 @@
+//
+//  UpdateRoomRequest.swift
+//  Models
+//
+//  Created by 송지혁 on 4/30/26.
+//
+
+public struct UpdateRoomRequest: Sendable {
+    public init() { }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -50,8 +50,36 @@ let project = Project(
                 destinations: .iOS,
                 product: .framework,
                 bundleId: "io.tuist.MGAME.ClientRoom",
-                sources: ["Clients/RoomClient/Sources/**"],
-                dependencies: [.target(name: "Models"), .external(name: "ComposableArchitecture")]
+                sources: ["Clients/RoomClient/Interface/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .external(name: "ComposableArchitecture")
+                ]
+            ),
+        
+            .target(name: "ClientRoomLive",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientRoomLive",
+                    sources: ["Clients/RoomClient/Live/Sources/**"],
+                    dependencies: [
+                        .target(name: "ClientRoom"),
+                        .target(name: "Models"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(
+                name: "ClientRoomTest",
+                destinations: .iOS,
+                product: .framework,
+                bundleId: "io.tuist.MGAME.ClientRoomTest",
+                sources: ["Clients/RoomClient/Test/Sources/**"],
+                dependencies: [
+                    .target(name: "ClientRoom"),
+                    .target(name: "Models"),
+                    .external(name: "ComposableArchitecture")
+                ]
             ),
         
             .target(
@@ -153,6 +181,7 @@ let project = Project(
                 .target(name: "FeatureLobby"),
                 .target(name: "FeatureGame"),
                 .target(name: "ClientAuthLive"),
+                .target(name: "ClientRoomLive"),
                 .external(name: "ComposableArchitecture")
             ]
         ),


### PR DESCRIPTION
## 관련 이슈

closes #6

## 변경 사항
### RoomClient 역할 변경

- `ClientRoom` 모듈의 `RoomClient`의 역할이 구체적인 로직 구현체가 아닌 인터페이스 역할을 하는 구조체로 변경되었습니다.
```swift
import Foundation
import Models

public struct RoomClient: Sendable {
    public var createRoom: @Sendable (CreateRoomRequest) async throws -> Room
    public var fetchRoom: @Sendable (UUID) async throws -> Room
    public var updateRoom: @Sendable (UUID, UpdateRoomRequest) async throws -> Room
    public var closeRoom: @Sendable (UUID) async throws -> Void
    
    public init(
        createRoom: @escaping @Sendable (CreateRoomRequest) async throws -> Room,
        fetchRoom: @escaping @Sendable (UUID) async throws -> Room,
        updateRoom: @escaping @Sendable (UUID, UpdateRoomRequest) async throws -> Room,
        closeRoom: @escaping @Sendable (UUID) async throws -> Void) {
            
        self.createRoom = createRoom
        self.fetchRoom = fetchRoom
        self.updateRoom = updateRoom
        self.closeRoom = closeRoom
    }
}



```

### Live/Test 구현 모듈 분리

- `RoomClient` 인터페이스를 기반으로 실제 실행 환경과 테스트 환경에서 사용할 구현체를 각각 분리했습니다.

```swift
// RoomClient+Live

import ClientRoom

public extension RoomClient {
    static let live = RoomClient { _ in
        fatalError("room live implementation is not implemented yet")
    } fetchRoom: { _ in
        fatalError("room live implementation is not implemented yet")
    } updateRoom: { _, _ in
        fatalError("room live implementation is not implemented yet")
    } closeRoom: { _ in
        fatalError("room live implementation is not implemented yet")
    }
}



```

```swift
// RoomClient+Test

import ClientRoom
import Models

public extension RoomClient {
    static let mockSuccess = RoomClient { _ in
        Room()
    } fetchRoom: { _ in
        Room()
    } updateRoom: { _, _ in
        Room()
    } closeRoom: { _ in }
}


```

## 기대 효과
- Feature 모듈이 `RoomClient`의 구체 구현이 아닌 인터페이스에만 의존하게 되어 모듈 간 결합도가 낮아졌습니다.
- `ClientRoomLive`와 `ClientRoomTest`를 분리하여 실행 환경과 테스트 환경의 경계를 명확히 나눴습니다.
- 


## 스크린샷

| Before | After |
|--------|-------|
| <img width="830" height="702" alt="image" src="https://github.com/user-attachments/assets/5443a28b-91f9-4356-9187-26c2c637ceda" /> | <img width="1000" height="702" alt="image" src="https://github.com/user-attachments/assets/02a34cfd-5897-48b9-b5bd-7076cc78fbf1" /> |


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive room management capabilities to the application, including the ability to create new rooms, retrieve existing rooms by identifier, update room details, and close rooms.

* **Tests**
  * Added mock implementations and test support for room management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->