### PR TITLE
[Foundation] ClientMusic 모듈 인터페이스/구현 모듈 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:

--- a/Clients/MusicClient/Interface/Sources/MusicClient.swift
+++ b/Clients/MusicClient/Interface/Sources/MusicClient.swift
@@ -1,0 +1,9 @@
+import Models
+
+public struct MusicClient: Sendable {
+    public var fetchSongs: @Sendable (SongRequest) async throws -> [Song]
+    
+    public init(fetchSongs: @escaping @Sendable (SongRequest) async throws -> [Song]) {
+        self.fetchSongs = fetchSongs
+    }
+}

--- a/Clients/MusicClient/Interface/Sources/MusicClientKey.swift
+++ b/Clients/MusicClient/Interface/Sources/MusicClientKey.swift
@@ -1,0 +1,19 @@
+//
+//  MusicClientKey.swift
+//  ClientMusic
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import Dependencies
+
+extension MusicClient: DependencyKey {
+    public static let liveValue: MusicClient = MusicClient(fetchSongs: unimplemented("MusicClient.fetchSongs"))
+}
+
+extension DependencyValues {
+    public var musicClient: MusicClient {
+        get { self[MusicClient.self] }
+        set { self[MusicClient.self] = newValue }
+    }
+}

--- a/Clients/MusicClient/Live/Sources/MusicClient+Live.swift
+++ b/Clients/MusicClient/Live/Sources/MusicClient+Live.swift
@@ -1,0 +1,15 @@
+//
+//  MusicClient+Live.swift
+//  ClientMusicLive
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientMusic
+
+public extension MusicClient {
+    static let live = MusicClient { _ in
+        fatalError("fetch live implementation is not implemented yet")
+    }
+}
+

--- a/Clients/MusicClient/Test/Sources/MusicClient+Test.swift
+++ b/Clients/MusicClient/Test/Sources/MusicClient+Test.swift
@@ -1,0 +1,15 @@
+//
+//  MusicClientTest.swift
+//  ClientMusicTest
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientMusic
+import Models
+
+public extension MusicClient {
+    static let mockSuccess = MusicClient { _ in
+        [Song()]
+    }
+}

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,4 +1,5 @@
 import ClientAuthLive
+import ClientMusicLive
 import ClientRoomLive
 import ComposableArchitecture
 import SwiftUI
@@ -9,7 +10,9 @@ struct MGAMEApp: App {
         AppFeature()
     } withDependencies: {
         $0.authClient = .live
+        $0.musicClient = .live
         $0.roomClient = .live
+        
     }
     
     var body: some Scene {

--- a/Models/Sources/Domain/Music/Song.swift
+++ b/Models/Sources/Domain/Music/Song.swift
@@ -1,0 +1,10 @@
+//
+//  Song.swift
+//  ClientAudio
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+public struct Song {
+    public init() { }
+}

--- a/Models/Sources/Domain/Music/SongRequest.swift
+++ b/Models/Sources/Domain/Music/SongRequest.swift
@@ -1,0 +1,10 @@
+//
+//  SongRequest.swift
+//  ClientAudio
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+public struct SongRequest: Sendable, Codable {
+    public init() { }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -96,9 +96,35 @@ let project = Project(
                 destinations: .iOS,
                 product: .framework,
                 bundleId: "io.tuist.MGAME.ClientMusic",
-                sources: ["Clients/MusicClient/Sources/**"],
-                dependencies: [.target(name: "Models"), .external(name: "ComposableArchitecture")]
+                sources: ["Clients/MusicClient/Interface/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .external(name: "ComposableArchitecture")
+                ]
             ),
+        
+            .target(name: "ClientMusicLive",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientMusicLive",
+                    sources: ["Clients/MusicClient/Live/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientMusic"),
+                        .external(name: "ComposableArchitecture")
+                    ]),
+        
+            .target(name: "ClientMusicTest",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientMusicTest",
+                    sources: ["Clients/MusicClient/Test/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientMusic"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
         
             .target(
                 name: "ClientAudio",
@@ -182,6 +208,7 @@ let project = Project(
                 .target(name: "FeatureGame"),
                 .target(name: "ClientAuthLive"),
                 .target(name: "ClientRoomLive"),
+                .target(name: "ClientMusicLive"),
                 .external(name: "ComposableArchitecture")
             ]
         ),


### PR DESCRIPTION
## 관련 이슈

closes #8 

## 변경 사항
- `ClientMusic` 모듈에 `MusicClient` Client interface 정의
```swift
import Models

public struct MusicClient: Sendable {
    public var fetchSongs: @Sendable (SongRequest) async throws -> [Song]
    
    public init(fetchSongs: @escaping @Sendable (SongRequest) async throws -> [Song]) {
        self.fetchSongs = fetchSongs
    }
}

```

- `MusicClient` 인터페이스를 기반 Live/Test 객체 생성

```swift
import ClientMusic

public extension MusicClient {
    static let live = MusicClient { _ in
        fatalError("fetch live implementation is not implemented yet")
    }
}

```

```swift
import ClientMusic
import Models

public extension MusicClient {
    static let mockSuccess = MusicClient { _ in
        [Song()]
    }
}

```


## 스크린샷

| Before | After |
|--------|-------|
<img width="541" height="421" alt="image" src="https://github.com/user-attachments/assets/4e3a1a59-215a-4dcc-adae-b1c0d9758148" /> | <img width="478" height="308" alt="image" src="https://github.com/user-attachments/assets/49b9dc5e-a693-4c8f-a4ea-664c9530d481" />
 |


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added music client infrastructure for fetching and managing songs throughout the app
  * Introduced song data models to support music functionality

* **Chores**
  * Updated CI workflow to include the develop branch in automated testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->