### PR TITLE
[Foundation] ClientGame, ClientWebSocket 모듈 인터페이스/구현 분리 및 클라이언트 레이어 분리

### DIFF
--- a/Clients/GameClient/Interface/Sources/GameClient.swift
+++ b/Clients/GameClient/Interface/Sources/GameClient.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Models
+
+public struct GameClient: Sendable {
+    public var connect: @Sendable (UUID) async throws -> Void
+    public var submitAnswer: @Sendable (String) async throws -> Void
+    public var gameEvents: @Sendable () -> AsyncStream<GameEvent>
+    public var disconnect: @Sendable () async throws -> Void
+    
+    public init(connect: @Sendable @escaping (UUID) async throws -> Void,
+                submitAnswer: @Sendable @escaping (String) async throws -> Void,
+                gameEvents: @Sendable @escaping () -> AsyncStream<GameEvent>,
+                disconnect: @Sendable @escaping () async throws -> Void) {
+        self.connect = connect
+        self.submitAnswer = submitAnswer
+        self.gameEvents = gameEvents
+        self.disconnect = disconnect
+    }
+}

--- a/Clients/GameClient/Interface/Sources/GameClientKey.swift
+++ b/Clients/GameClient/Interface/Sources/GameClientKey.swift
@@ -1,0 +1,22 @@
+//
+//  GameClientKey.swift
+//  ClientGame
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import Dependencies
+
+extension GameClient: DependencyKey {
+    static public var liveValue: GameClient = GameClient(connect: unimplemented("GameClient.connect"),
+                                                         submitAnswer: unimplemented("GameClient.submitAnswer"),
+                                                         gameEvents: unimplemented("GameClient.gameEvents"),
+                                                         disconnect: unimplemented("GameClient.disconnect"))
+}
+
+extension DependencyValues {
+    public var gameClient: GameClient {
+        get { self[GameClient.self] }
+        set { self[GameClient.self] = newValue }
+    }
+}

--- a/Clients/GameClient/Live/Sources/GameClient+Live.swift
+++ b/Clients/GameClient/Live/Sources/GameClient+Live.swift
@@ -1,0 +1,21 @@
+//
+//  WebSocketClient+Live.swift
+//  ClientGameLive
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientGame
+
+public extension GameClient {
+    static let live = GameClient { _ in
+        fatalError("game connect live implementation is not implemented yet")
+    } submitAnswer: { _ in
+        fatalError("game submit answer live implementation is not implemented yet")
+    } gameEvents: {
+        fatalError("game events live implementation is not implemented yet")
+    } disconnect: {
+        fatalError("game disconnect live implementation is not implemented yet")
+    }
+
+}

--- a/Clients/GameClient/Test/Sources/GameClient+Test.swift
+++ b/Clients/GameClient/Test/Sources/GameClient+Test.swift
@@ -1,0 +1,21 @@
+//
+//  WebSocketClient+Test.swift
+//  ClientGameTest
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientGame
+import Models
+
+public extension GameClient {
+    static let mockSuccess = GameClient { _ in
+        
+    } submitAnswer: { _ in
+        
+    } gameEvents: {
+        AsyncStream<GameEvent> { $0.finish() }
+    } disconnect: {
+        
+    }
+}

--- a/Clients/WebSocketClient/Interface/Sources/WebSocketClient.swift
+++ b/Clients/WebSocketClient/Interface/Sources/WebSocketClient.swift
@@ -1,0 +1,26 @@
+//
+//  WebSocketClient.swift
+//  ClientWebSocket
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import Foundation
+
+public struct WebSocketClient: Sendable {
+    public var connect: @Sendable (URL) async throws -> Void
+    public var send: @Sendable (String) async throws -> Void
+    public var receive: @Sendable () -> AsyncStream<String>
+    public var disconnect: @Sendable () async throws -> Void
+    
+    public init(connect: @escaping @Sendable (URL) async throws -> Void,
+                send: @escaping @Sendable (String) async throws -> Void,
+                receive: @escaping @Sendable () -> AsyncStream<String>,
+                disconnect: @escaping @Sendable () async throws -> Void) {
+        self.connect = connect
+        self.send = send
+        self.receive = receive
+        self.disconnect = disconnect
+    }
+    
+}

--- a/Clients/WebSocketClient/Interface/Sources/WebSocketClientKey.swift
+++ b/Clients/WebSocketClient/Interface/Sources/WebSocketClientKey.swift
@@ -1,0 +1,22 @@
+//
+//  WebSocketClientKey.swift
+//  ClientWebSocket
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import Dependencies
+
+extension WebSocketClient: DependencyKey {
+    static public var liveValue = WebSocketClient(connect: unimplemented("WebSocketClient.connect"),
+                                                  send: unimplemented("WebSocketClient.send"),
+                                                  receive: unimplemented("WebSocketClient.receive"),
+                                                  disconnect: unimplemented("WebSocketClient.disconnect"))
+}
+
+extension DependencyValues {
+    public var webSocketClient: WebSocketClient {
+        get { self[WebSocketClient.self] }
+        set { self[WebSocketClient.self] = newValue }
+    }
+}

--- a/Clients/WebSocketClient/Live/Sources/WebSocketClient+Live.swift
+++ b/Clients/WebSocketClient/Live/Sources/WebSocketClient+Live.swift
@@ -1,0 +1,20 @@
+//
+//  WebSocketClient+Live.swift
+//  ClientWebSocket
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientWebSocket
+
+public extension WebSocketClient {
+    static let live: WebSocketClient = WebSocketClient { _ in
+        fatalError("websocket connect live implementation is not implemented yet")
+    } send: { _ in
+        fatalError("websocket send live implementation is not implemented yet")
+    } receive: {
+        fatalError("websocket receive live implementation is not implemented yet")
+    } disconnect: {
+        fatalError("websocket disconnect live implementation is not implemented yet")
+    }
+}

--- a/Clients/WebSocketClient/Test/Sources/WebSocketClient+Test.swift
+++ b/Clients/WebSocketClient/Test/Sources/WebSocketClient+Test.swift
@@ -1,0 +1,21 @@
+//
+//  WebSocketClient+Test.swift
+//  ClientWebSocket
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientWebSocket
+import Models
+
+public extension WebSocketClient {
+    static let mockSuccess = WebSocketClient { _ in
+        
+    } send: { _ in
+        
+    } receive: {
+        AsyncStream<String> { $0.finish() }
+    } disconnect: {
+        
+    }
+}

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,6 +1,8 @@
 import ClientAuthLive
+import ClientGameLive
 import ClientMusicLive
 import ClientRoomLive
+import ClientWebSocketLive
 import ComposableArchitecture
 import SwiftUI
 
@@ -12,6 +14,8 @@ struct MGAMEApp: App {
         $0.authClient = .live
         $0.musicClient = .live
         $0.roomClient = .live
+        $0.gameClient = .live
+        $0.webSocketClient = .live
         
     }
     

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -2,7 +2,6 @@ import ClientAuthLive
 import ClientGameLive
 import ClientMusicLive
 import ClientRoomLive
-import ClientWebSocketLive
 import ComposableArchitecture
 import SwiftUI
 
@@ -15,8 +14,6 @@ struct MGAMEApp: App {
         $0.musicClient = .live
         $0.roomClient = .live
         $0.gameClient = .live
-        $0.webSocketClient = .live
-        
     }
     
     var body: some Scene {

--- a/Models/Sources/Domain/Game/GameEvent.swift
+++ b/Models/Sources/Domain/Game/GameEvent.swift
@@ -1,0 +1,10 @@
+//
+//  GameEvent.swift
+//  Models
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+public struct GameEvent {
+    public init() { }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -83,13 +83,79 @@ let project = Project(
             ),
         
             .target(
-                name: "ClientWebSocket",
+                name: "ClientGame",
                 destinations: .iOS,
                 product: .framework,
-                bundleId: "io.tuist.MGAME.ClientWebSocket",
-                sources: ["Clients/WebSocketClient/Sources/**"],
-                dependencies: [.target(name: "Models"), .external(name: "ComposableArchitecture")]
+                bundleId: "io.tuist.MGAME.ClientGame",
+                sources: ["Clients/GameClient/Interface/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .external(name: "ComposableArchitecture")
+                ]
             ),
+        
+            .target(name: "ClientGameLive",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientGameLive",
+                    sources: ["Clients/GameClient/Live/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientGame"),
+                        .target(name: "ClientWebSocket"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(name: "ClientGameTest",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientGameTest",
+                    sources: ["Clients/GameClient/Test/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientGame"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(name: "ClientWebSocket",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientWebSocket",
+                    sources: ["Clients/WebSocketClient/Interface/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+        
+            .target(name: "ClientWebSocketLive",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientWebSocketLive",
+                    sources: ["Clients/WebSocketClient/Live/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientWebSocket"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+            .target(name: "ClientWebSocketTest",
+                    destinations: .iOS,
+                    product: .framework,
+                    bundleId: "io.tuist.MGAME.ClientWebSocketTest",
+                    sources: ["Clients/WebSocketClient/Test/Sources/**"],
+                    dependencies: [
+                        .target(name: "Models"),
+                        .target(name: "ClientWebSocket"),
+                        .external(name: "ComposableArchitecture")
+                    ]
+                   ),
+        
+        
         
             .target(
                 name: "ClientMusic",
@@ -172,7 +238,7 @@ let project = Project(
             dependencies: [
                 .target(name: "MDS"),
                 .target(name: "Models"),
-                .target(name: "ClientWebSocket"),
+                .target(name: "ClientGame"),
                 .target(name: "ClientMusic"),
                 .target(name: "ClientAudio"),
                 .external(name: "ComposableArchitecture")
@@ -209,6 +275,7 @@ let project = Project(
                 .target(name: "ClientAuthLive"),
                 .target(name: "ClientRoomLive"),
                 .target(name: "ClientMusicLive"),
+                .target(name: "ClientGameLive"),
                 .external(name: "ComposableArchitecture")
             ]
         ),


### PR DESCRIPTION
## 관련 이슈

closes #10 

## 변경 사항
### ClientGame / ClientWebSocket 레이어 분리

기존 Client 모듈들은 모두 하나의 레이어에 있었는데, 
WebSocket은 도메인이 아니라 네트워크 전송 기술이라 도메인 Client들과 레이어가 맞지 않다고 판단했습니다.

이를 해결하기 위해 Client 레이어를 두 단계로 분리:

`Domain Client` — `GameClient`, `MusicClient`, `RoomClient` 등 도메인 언어로 상위 모듈에 기능을 노출
`Infra Client` — `WebSocketClient`는 전송만 담당

<br />

### Interface/Live/Test 모듈 분리
ClientAuth, ClientRoom과 동일한 패턴으로 분리했습니다.


## 스크린샷

<img width="845" height="533" alt="image" src="https://github.com/user-attachments/assets/510c8539-8d9b-4c4a-bcbf-a7181971d8a3" />
 |


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added game communication infrastructure to support upcoming game features
  * Implemented WebSocket connectivity layer for real-time interactions
  * Reorganized project structure to better modularize game and communication clients
  * Created test utilities to support quality assurance of new game functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->