### PR TITLE
[Foundation] ClientAudio 인터페이스/구현 분리

### DIFF
--- a/Clients/AudioClient/Interface/Sources/AudioClient.swift
+++ b/Clients/AudioClient/Interface/Sources/AudioClient.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct AudioClient: Sendable {
+    public var preload: @Sendable (URL) async throws -> Void
+    public var play: @Sendable () async throws -> Void
+    public var stop: @Sendable () async throws -> Void
+    
+    public init(preload: @Sendable @escaping (URL) async throws -> Void,
+                play: @Sendable @escaping () async throws -> Void,
+                stop: @Sendable @escaping () async throws -> Void) {
+        self.preload = preload
+        self.play = play
+        self.stop = stop
+    }
+}

--- a/Clients/AudioClient/Interface/Sources/AudioClientKey.swift
+++ b/Clients/AudioClient/Interface/Sources/AudioClientKey.swift
@@ -1,0 +1,22 @@
+//
+//  AudioClientKey.swift
+//  ClientAudio
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import Dependencies
+
+extension AudioClient: DependencyKey {
+    public static let liveValue = AudioClient(preload: unimplemented("AudioClient.preload"),
+                                              play: unimplemented("AudioClient.play"),
+                                              stop: unimplemented("AudioClient.stop"))
+}
+
+extension DependencyValues {
+    public var audioClient: AudioClient {
+        get { self[AudioClient.self] }
+        set { self[AudioClient.self] = newValue }
+    }
+}
+

--- a/Clients/AudioClient/Live/Sources/AudioClient+Live.swift
+++ b/Clients/AudioClient/Live/Sources/AudioClient+Live.swift
@@ -1,0 +1,19 @@
+//
+//  AudioClient+Live.swift
+//  ClientAudio
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientAudio
+
+public extension AudioClient {
+    static let live = AudioClient { _ in
+        fatalError("preload live implementation is not implemented yet")
+    } play: {
+        fatalError("play live implementation is not implemented yet")
+    } stop: {
+        fatalError("stop live implementation is not implemented yet")
+    }
+
+}

--- a/Clients/AudioClient/Test/Sources/AudioClient+Test.swift
+++ b/Clients/AudioClient/Test/Sources/AudioClient+Test.swift
@@ -1,0 +1,20 @@
+//
+//  AudioClient+Test.swift
+//  ClientAudio
+//
+//  Created by 송지혁 on 5/2/26.
+//
+
+import ClientAudio
+import Models
+
+public extension AudioClient {
+    static let mockSuccess = AudioClient { _ in
+        
+    } play: {
+        
+    } stop: {
+        
+    }
+}
+

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -1,3 +1,4 @@
+import ClientAudioLive
 import ClientAuthLive
 import ClientGameLive
 import ClientMusicLive
@@ -14,6 +15,7 @@ struct MGAMEApp: App {
         $0.musicClient = .live
         $0.roomClient = .live
         $0.gameClient = .live
+        $0.audioClient = .live
     }
     
     var body: some Scene {

--- a/Project.swift
+++ b/Project.swift
@@ -197,8 +197,37 @@ let project = Project(
                 destinations: .iOS,
                 product: .framework,
                 bundleId: "io.tuist.MGAME.ClientAudio",
-                sources: ["Clients/AudioClient/Sources/**"],
-                dependencies: []
+                sources: ["Clients/AudioClient/Interface/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .external(name: "ComposableArchitecture")
+                ]
+            ),
+        
+            .target(
+                name: "ClientAudioLive",
+                destinations: .iOS,
+                product: .framework,
+                bundleId: "io.tuist.MGAME.ClientAudioLive",
+                sources: ["Clients/AudioClient/Live/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .target(name: "ClientAudio"),
+                    .external(name: "ComposableArchitecture")
+                ]
+            ),
+        
+            .target(
+                name: "ClientAudioTest",
+                destinations: .iOS,
+                product: .framework,
+                bundleId: "io.tuist.MGAME.ClientAudioTest",
+                sources: ["Clients/AudioClient/Test/Sources/**"],
+                dependencies: [
+                    .target(name: "Models"),
+                    .target(name: "ClientAudio"),
+                    .external(name: "ComposableArchitecture")
+                ]
             ),
         
             .target(
@@ -272,6 +301,7 @@ let project = Project(
                 .target(name: "FeatureLogin"),
                 .target(name: "FeatureLobby"),
                 .target(name: "FeatureGame"),
+                .target(name: "ClientAudioLive"),
                 .target(name: "ClientAuthLive"),
                 .target(name: "ClientRoomLive"),
                 .target(name: "ClientMusicLive"),


### PR DESCRIPTION
## 관련 이슈

closes #12 

## 변경 사항
### AudioClient Interface · Live · Test 모듈 분리
다른 Client 모듈들과 동일한 패턴으로 Client interface를 정의하고 Live/Test 구현체를 분리

## 스크린샷
<img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/2b648b40-ac08-4c9e-9b06-07aa8833ed97" />


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced audio client with preload, play, and stop capabilities
  * Integrated audio client into the dependency injection system for app-wide access
  * Added test and mock utilities for audio client functionality

* **Chores**
  * Updated project configuration to support new audio client targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->