### PR TITLE
[Spike] 실기기 WebSocket 통신(Server-Hub-Room, Broadcast) 테스트

### DIFF
--- a/Models/Sources/DTO/GameMessage.swift
+++ b/Models/Sources/DTO/GameMessage.swift
@@ -1,0 +1,39 @@
+//
+//  Message.swift
+//  Models
+//
+//  Created by 송지혁 on 5/12/26.
+//
+
+import Foundation
+
+enum GameMessage {
+    case playerJoined(PlayerJoinedPayload)
+    case playerLeft(PlayerLeftPayload)
+}
+
+extension GameMessage: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case type = "Type"
+        case payload = "Payload"
+        case timestamp = "Timestamp"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        
+        switch type {
+            case "PLAYER_JOINED":
+                let payload = try container.decode(PlayerJoinedPayload.self, forKey: .payload)
+                self = .playerJoined(payload)
+                
+            case "PLAYER_LEFT":
+                let payload = try container.decode(PlayerLeftPayload.self, forKey: .payload)
+                self = .playerLeft(payload)
+                
+            default:
+                throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown type: \(type)")
+        }
+    }
+}

--- a/Models/Sources/DTO/GameMessage.swift
+++ b/Models/Sources/DTO/GameMessage.swift
@@ -33,7 +33,7 @@ extension GameMessage: Decodable {
                 self = .playerLeft(payload)
                 
             default:
-                throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Unknown type: \(type)")
+                self = .unknown
         }
     }
 }

--- a/Models/Sources/DTO/GameMessage.swift
+++ b/Models/Sources/DTO/GameMessage.swift
@@ -7,9 +7,10 @@
 
 import Foundation
 
-enum GameMessage {
+public enum GameMessage {
     case playerJoined(PlayerJoinedPayload)
     case playerLeft(PlayerLeftPayload)
+    case unknown
 }
 
 extension GameMessage: Decodable {
@@ -19,7 +20,7 @@ extension GameMessage: Decodable {
         case timestamp = "Timestamp"
     }
     
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(String.self, forKey: .type)
         

--- a/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
@@ -5,7 +5,6 @@
 //  Created by 송지혁 on 5/12/26.
 //
 
-
 struct PlayerJoinedPayload: Codable {
     let playerId: String
     

--- a/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
@@ -1,3 +1,11 @@
+//
+//  PlayerJoinedPayload.swift
+//  M_GAME
+//
+//  Created by 송지혁 on 5/12/26.
+//
+
+
 struct PlayerJoinedPayload: Codable {
     let playerId: String
     

--- a/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
@@ -5,8 +5,8 @@
 //  Created by 송지혁 on 5/12/26.
 //
 
-struct PlayerJoinedPayload: Codable {
-    let playerId: String
+public struct PlayerJoinedPayload: Codable {
+    public let playerId: String
     
     enum CodingKeys: String, CodingKey {
         case playerId = "PlayerID"

--- a/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerJoinedPayload.swift
@@ -1,0 +1,7 @@
+struct PlayerJoinedPayload: Codable {
+    let playerId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case playerId = "PlayerID"
+    }
+}

--- a/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
@@ -5,7 +5,6 @@
 //  Created by 송지혁 on 5/12/26.
 //
 
-
 struct PlayerLeftPayload: Codable {
     let playerId: String
     

--- a/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
@@ -1,0 +1,7 @@
+struct PlayerLeftPayload: Codable {
+    let playerId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case playerId = "PlayerID"
+    }
+}

--- a/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
@@ -5,8 +5,8 @@
 //  Created by 송지혁 on 5/12/26.
 //
 
-struct PlayerLeftPayload: Codable {
-    let playerId: String
+public struct PlayerLeftPayload: Codable {
+    public let playerId: String
     
     enum CodingKeys: String, CodingKey {
         case playerId = "PlayerID"

--- a/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
+++ b/Models/Sources/DTO/Payload/PlayerLeftPayload.swift
@@ -1,3 +1,11 @@
+//
+//  PlayerLeftPayload.swift
+//  M_GAME
+//
+//  Created by 송지혁 on 5/12/26.
+//
+
+
 struct PlayerLeftPayload: Codable {
     let playerId: String
     

--- a/Project.swift
+++ b/Project.swift
@@ -5,14 +5,14 @@ let project = Project(
     targets: [
         .target(name: "Models",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.Models",
                 sources: ["Models/Sources/**"]
                ),
         
             .target(name: "ClientAuth",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientAuth",
                     sources: ["Clients/AuthClient/Interface/Sources/**"],
                     dependencies: [
@@ -23,7 +23,7 @@ let project = Project(
         
             .target(name: "ClientAuthLive",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientAuthLive",
                     sources: ["Clients/AuthClient/Live/Sources/**"],
                     dependencies: [
@@ -35,7 +35,7 @@ let project = Project(
         
             .target(name: "ClientAuthTest",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientAuthTest",
                     sources: ["Clients/AuthClient/Test/Sources/**"],
                     dependencies: [
@@ -48,7 +48,7 @@ let project = Project(
             .target(
                 name: "ClientRoom",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientRoom",
                 sources: ["Clients/RoomClient/Interface/Sources/**"],
                 dependencies: [
@@ -59,7 +59,7 @@ let project = Project(
         
             .target(name: "ClientRoomLive",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientRoomLive",
                     sources: ["Clients/RoomClient/Live/Sources/**"],
                     dependencies: [
@@ -72,7 +72,7 @@ let project = Project(
             .target(
                 name: "ClientRoomTest",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientRoomTest",
                 sources: ["Clients/RoomClient/Test/Sources/**"],
                 dependencies: [
@@ -85,7 +85,7 @@ let project = Project(
             .target(
                 name: "ClientGame",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientGame",
                 sources: ["Clients/GameClient/Interface/Sources/**"],
                 dependencies: [
@@ -96,7 +96,7 @@ let project = Project(
         
             .target(name: "ClientGameLive",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientGameLive",
                     sources: ["Clients/GameClient/Live/Sources/**"],
                     dependencies: [
@@ -109,7 +109,7 @@ let project = Project(
         
             .target(name: "ClientGameTest",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientGameTest",
                     sources: ["Clients/GameClient/Test/Sources/**"],
                     dependencies: [
@@ -121,7 +121,7 @@ let project = Project(
         
             .target(name: "ClientWebSocket",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientWebSocket",
                     sources: ["Clients/WebSocketClient/Interface/Sources/**"],
                     dependencies: [
@@ -133,7 +133,7 @@ let project = Project(
         
             .target(name: "ClientWebSocketLive",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientWebSocketLive",
                     sources: ["Clients/WebSocketClient/Live/Sources/**"],
                     dependencies: [
@@ -145,7 +145,7 @@ let project = Project(
         
             .target(name: "ClientWebSocketTest",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientWebSocketTest",
                     sources: ["Clients/WebSocketClient/Test/Sources/**"],
                     dependencies: [
@@ -160,7 +160,7 @@ let project = Project(
             .target(
                 name: "ClientMusic",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientMusic",
                 sources: ["Clients/MusicClient/Interface/Sources/**"],
                 dependencies: [
@@ -171,7 +171,7 @@ let project = Project(
         
             .target(name: "ClientMusicLive",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientMusicLive",
                     sources: ["Clients/MusicClient/Live/Sources/**"],
                     dependencies: [
@@ -182,7 +182,7 @@ let project = Project(
         
             .target(name: "ClientMusicTest",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.ClientMusicTest",
                     sources: ["Clients/MusicClient/Test/Sources/**"],
                     dependencies: [
@@ -195,7 +195,7 @@ let project = Project(
             .target(
                 name: "ClientAudio",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientAudio",
                 sources: ["Clients/AudioClient/Interface/Sources/**"],
                 dependencies: [
@@ -207,7 +207,7 @@ let project = Project(
             .target(
                 name: "ClientAudioLive",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientAudioLive",
                 sources: ["Clients/AudioClient/Live/Sources/**"],
                 dependencies: [
@@ -220,7 +220,7 @@ let project = Project(
             .target(
                 name: "ClientAudioTest",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.ClientAudioTest",
                 sources: ["Clients/AudioClient/Test/Sources/**"],
                 dependencies: [
@@ -233,7 +233,7 @@ let project = Project(
             .target(
                 name: "FeatureLogin",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.FeatureLogin",
                 sources: ["Features/Login/Sources/**"],
                 dependencies: [
@@ -246,7 +246,7 @@ let project = Project(
         .target(
             name: "FeatureLobby",
             destinations: .iOS,
-            product: .framework,
+            product: .staticFramework,
             bundleId: "io.tuist.MGAME.FeatureLobby",
             sources: ["Features/Lobby/Sources/**"],
             dependencies: [
@@ -254,6 +254,7 @@ let project = Project(
                 .target(name: "Models"),
                 .target(name: "ClientAuth"),
                 .target(name: "ClientRoom"),
+                .target(name: "ClientWebSocket"),
                 .external(name: "ComposableArchitecture")
             ]
         ),
@@ -261,7 +262,7 @@ let project = Project(
             .target(
                 name: "FeatureGame",
                 destinations: .iOS,
-                product: .framework,
+                product: .staticFramework,
                 bundleId: "io.tuist.MGAME.FeatureGame",
                 sources: ["Features/Game/Sources/**"],
                 dependencies: [
@@ -289,7 +290,7 @@ let project = Project(
         
             .target(name: "MDS",
                     destinations: .iOS,
-                    product: .framework,
+                    product: .staticFramework,
                     bundleId: "io.tuist.MGAME.MDS",
                     sources: ["Shared/MDS/Sources/**"],
                     resources: ["Shared/MDS/Resources/**"]
@@ -319,6 +320,7 @@ let project = Project(
                     .target(name: "ClientRoomLive"),
                     .target(name: "ClientMusicLive"),
                     .target(name: "ClientGameLive"),
+                    .target(name: "ClientWebSocketLive"),
                     .external(name: "ComposableArchitecture")
                 ]
             ),


### PR DESCRIPTION
## 관련 이슈

closes #16 

## 배경
Go 서버(Hub/Room) ↔ iOS 간 WebSocket 통신이 실기기에서 동작하는지 테스트 수행.

## 검증 결과
- iPhone 2대에서 동일 roomID로 접속 성공
- PLAYER_JOINED / PLAYER_LEFT broadcast 양방향 수신 확인

## 변경 사항
- `GameMessage`, `PlayerJoinedPayload`, `PlayerLeftPayload` 모델 추가
- 전체 모듈 product를 `.staticFramework`로 변경 (TCA + Tuist 런타임 크래시 해결)

## 스크린샷 / 영상

https://github.com/user-attachments/assets/60869d9f-b4d7-43d6-9206-f0c065c45e03



## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiplayer game messaging capabilities, enabling real-time detection and handling of player join and leave events during active game sessions.

* **Chores**
  * Optimized framework architecture by reconfiguring modules for improved build performance and enhanced dependency management to better support multi-module structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/temp-pj/temp-iOS/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->