### PR TITLE
[Feat] RoomReducer-GameReducer 음악 재생 플로우 구현

### DIFF
--- a/Features/Room/Sources/Game/GameReducer.swift
+++ b/Features/Room/Sources/Game/GameReducer.swift
@@ -14,9 +14,7 @@ public struct GameReducer {
         public var roundState: RoundState = .idle
         public var inputState: InputState = .enabled
         public var roundData: RoundData?
-        public var songURL: URL?
         public var roundResult: RoundResult?
-        
     }
     
     public enum Action {
@@ -28,6 +26,8 @@ public struct GameReducer {
         case serverEvent(GameEvent)
         
         public enum Delegate {
+            case playMusic
+            case stopMusic
             case submitAnswer(String)
         }
     }
@@ -68,16 +68,12 @@ public struct GameReducer {
                 case .serverEvent(let event):
                     switch event {
                             
-                        case .preloadSong(let url):
-                            state.roundState = .loading(url)
-                            state.songURL = url
-                            return .none
                             
                         case .roundStarted(let data):
                             state.roundData = data
                             state.roundState = .playing
                             state.inputState = .enabled
-                            return .none
+                            return .send(.delegate(.playMusic))
                             
                         case .wrongAnswer:
                             state.inputState = .penalized
@@ -92,12 +88,11 @@ public struct GameReducer {
                             state.roundState = .result
                             state.roundResult = result
                             
-                            return .none
+                            return .send(.delegate(.stopMusic))
                             
                         case .nextRound:
                             state.roundData = nil
                             state.roundResult = nil
-                            state.songURL = nil
                             state.inputState = .enabled
                             state.roundState = .idle
                             state.selectedLetters = []

--- a/Features/Room/Sources/Game/GameReducer.swift
+++ b/Features/Room/Sources/Game/GameReducer.swift
@@ -67,8 +67,6 @@ public struct GameReducer {
                     
                 case .serverEvent(let event):
                     switch event {
-                            
-                            
                         case .roundStarted(let data):
                             state.roundData = data
                             state.roundState = .playing

--- a/Features/Room/Sources/Room/RoomReducer.swift
+++ b/Features/Room/Sources/Room/RoomReducer.swift
@@ -5,6 +5,7 @@
 //  Created by 송지혁 on 5/12/26.
 //
 
+import ClientAudio
 import ClientRoomSession
 import ComposableArchitecture
 import Foundation
@@ -50,6 +51,7 @@ public struct RoomReducer {
     }
     
     @Dependency(\.roomSessionClient) var roomSession
+    @Dependency(\.audioClient) var audioClient
     
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
@@ -93,6 +95,12 @@ public struct RoomReducer {
                         case .roomClosed(let reason):
                             return .none
                             
+                        case .preloadSong(let song):
+                            return .run { send in
+                                // 추후에 여기서 startTime < endTime 방어 로직 구현
+                                try await audioClient.preload(song.id, song.startTime, song.endTime)
+                            }
+                            
                         case .game(let event):
                             return .send(.game(.serverEvent(event)))
                             
@@ -106,6 +114,16 @@ public struct RoomReducer {
                     
                 case .game(.delegate(.submitAnswer(let answer))):
                     return .send(.toServer(.game(.submitAnswer(answer))))
+                    
+                case .game(.delegate(.playMusic)):
+                    return .run { send in
+                        try await audioClient.play()
+                    }
+                
+                case .game(.delegate(.stopMusic)):
+                    return .run { send in
+                        try await audioClient.stop()
+                    }
                     
                 case .onDisappear:
                     return .merge(

--- a/Features/Room/Sources/Room/RoomReducer.swift
+++ b/Features/Room/Sources/Room/RoomReducer.swift
@@ -96,7 +96,7 @@ public struct RoomReducer {
                             return .none
                             
                         case .preloadSong(let song):
-                            return .run { send in
+                            return .run { _ in
                                 // 추후에 여기서 startTime < endTime 방어 로직 구현
                                 try await audioClient.preload(song.id, song.startTime, song.endTime)
                             }
@@ -116,12 +116,12 @@ public struct RoomReducer {
                     return .send(.toServer(.game(.submitAnswer(answer))))
                     
                 case .game(.delegate(.playMusic)):
-                    return .run { send in
+                    return .run { _ in
                         try await audioClient.play()
                     }
                 
                 case .game(.delegate(.stopMusic)):
-                    return .run { send in
+                    return .run { _ in
                         try await audioClient.stop()
                     }
                     

--- a/Features/Room/Tests/RoomReducerTests.swift
+++ b/Features/Room/Tests/RoomReducerTests.swift
@@ -82,10 +82,9 @@ final class RoomReducerTests: XCTestCase {
         
         // preload Song
         let songID = "1675478652"
-        continuation.yield(.preloadSong(songID))
+        continuation.yield(.preloadSong(PreloadSong(id: songID, startTime: 0, endTime: 30)))
         
         await store.receive(\.receive)
-        
         
         // 라운드 시작
         let roundData = RoundData.mock(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만", "있", "다", "면", "마", "라", "탕"], answerLength: 6, timeLimit: 3600)
@@ -268,7 +267,7 @@ final class RoomReducerTests: XCTestCase {
         await store.send(.onAppear)
         
         // 에픽하이 - 우산
-        continuation.yield(.preloadSong("1675478652"))
+        continuation.yield(.preloadSong(PreloadSong(id: "1675478652", startTime: 0, endTime: 30)))
         
         await store.receive(\.receive)
         XCTAssertEqual(fetchedID, "1675478652")
@@ -310,7 +309,6 @@ final class RoomReducerTests: XCTestCase {
         continuation.finish()
         await store.send(.onDisappear)
     }
-    
     
     func test_라운드_종료() async {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)

--- a/Features/Room/Tests/RoomReducerTests.swift
+++ b/Features/Room/Tests/RoomReducerTests.swift
@@ -24,15 +24,22 @@ final class RoomReducerTests: XCTestCase {
         let player2 = Player(id: UUID())
         let player3 = Player(id: UUID())
         
+        var fetchedID: String?
         var request: RoomRequest?
+        var didPlay = false
+        var didStop = false
         
         let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
                                                                     hostID: hostPlayer.id,
                                                                     players: [hostPlayer.id: hostPlayer],
                                                                     roomState: .waiting),
                                     reducer: { RoomReducer() }) {
+            $0.audioClient.preload = { id, _, _ in fetchedID = id }
+            $0.audioClient.play = { didPlay = true }
+            $0.audioClient.stop = { didStop = true }
             $0.roomSessionClient = .mock(send: { request = $0 }, roomEvents: { stream })
             $0.continuousClock = clock
+            
         }
         
         let game = GameReducer.State(selectedLetters: [], roundState: .idle)
@@ -74,14 +81,11 @@ final class RoomReducerTests: XCTestCase {
         }
         
         // preload Song
-        let songURL = URL(string: "https://www.naver.com")!
-        continuation.yield(.game(.preloadSong(songURL)))
+        let songID = "1675478652"
+        continuation.yield(.preloadSong(songID))
         
         await store.receive(\.receive)
-        await store.receive(\.game) {
-            $0.gameState?.roundState = .loading(songURL)
-            $0.gameState?.songURL = songURL
-        }
+        
         
         // 라운드 시작
         let roundData = RoundData.mock(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만", "있", "다", "면", "마", "라", "탕"], answerLength: 6, timeLimit: 3600)
@@ -94,6 +98,9 @@ final class RoomReducerTests: XCTestCase {
             $0.gameState?.inputState = .enabled
             $0.gameState?.roundData = roundData
         }
+        await store.receive(\.game)
+        
+        XCTAssertEqual(didPlay, true)
         
         // 전송
         let wrongAnswer = ["마", "라", "탕", "있", "다", "면"]
@@ -128,6 +135,9 @@ final class RoomReducerTests: XCTestCase {
             $0.gameState?.roundResult = roundResult
             $0.gameState?.roundState = .result
         }
+        await store.receive(\.game)
+        
+        XCTAssertEqual(didStop, true)
         
         // 다음 라운드
         continuation.yield(.game(.nextRound))
@@ -138,7 +148,6 @@ final class RoomReducerTests: XCTestCase {
             $0.gameState?.inputState = .enabled
             $0.gameState?.roundData = nil
             $0.gameState?.roundResult = nil
-            $0.gameState?.songURL = nil
             $0.gameState?.selectedLetters = []
         }
         
@@ -243,6 +252,98 @@ final class RoomReducerTests: XCTestCase {
         continuation.finish()
         
         await store.send(.onDisappear)
+    }
+    
+    func test_노래_받기() async {
+        let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
+        var fetchedID: String?
+        
+        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: UUID(), players: [:], gameState: GameReducer.State())) {
+            RoomReducer()
+        } withDependencies: {
+            $0.roomSessionClient = .mock(roomEvents: { stream })
+            $0.audioClient.preload = { id, _, _ in fetchedID = id }
+        }
+        
+        await store.send(.onAppear)
+        
+        // 에픽하이 - 우산
+        continuation.yield(.preloadSong("1675478652"))
+        
+        await store.receive(\.receive)
+        XCTAssertEqual(fetchedID, "1675478652")
+        
+        continuation.finish()
+        await store.send(.onDisappear)
+    }
+    
+    func test_라운드_시작() async {
+        let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["타", "임", "캡", "슐"], answerLength: 4, timeLimit: 1000)
+        var didPlay = false
+        
+        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+                                                                    hostID: UUID(),
+                                                                    players: [:],
+                                                                    roomState: .playing,
+                                                                    gameState: GameReducer.State(roundState: .idle)
+                                                                   ),
+                                    reducer: { RoomReducer() }) {
+            $0.roomSessionClient = .mock(roomEvents: { stream })
+            $0.audioClient.play = { didPlay = true }
+        }
+        
+        await store.send(.onAppear)
+        
+        continuation.yield(.game(.roundStarted(roundData)))
+        
+        await store.receive(\.receive)
+        await store.receive(\.game) {
+            $0.gameState?.roundState = .playing
+            $0.gameState?.inputState = .enabled
+            $0.gameState?.roundData = roundData
+        }
+        await store.receive(\.game)
+        
+        XCTAssertEqual(didPlay, true)
+        
+        continuation.finish()
+        await store.send(.onDisappear)
+    }
+    
+    
+    func test_라운드_종료() async {
+        let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
+        let roundResult = RoundResult(winnerId: UUID(), correctAnswer: "편지", scores: [:])
+        var didStop = false
+        
+        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+                                                                    hostID: UUID(),
+                                                                    players: [:],
+                                                                    roomState: .playing,
+                                                                    gameState: GameReducer.State(roundState: .playing)
+                                                                   ), reducer: { RoomReducer() }) {
+            $0.roomSessionClient = .mock(roomEvents: { stream })
+            $0.audioClient.stop = { didStop = true }
+        }
+        
+        await store.send(.onAppear)
+        
+        continuation.yield(.game(.roundEnded(roundResult)))
+        
+        await store.receive(\.receive)
+        await store.receive(\.game) {
+            $0.gameState?.roundState = .result
+            $0.gameState?.roundResult = roundResult
+            $0.gameState?.inputState = .enabled
+        }
+        await store.receive(\.game)
+        
+        XCTAssertEqual(didStop, true)
+        
+        continuation.finish()
+        await store.send(.onDisappear)
+        
     }
     
     func test_게임_종료() async {

--- a/Models/Sources/Domain/Game/GameEvent.swift
+++ b/Models/Sources/Domain/Game/GameEvent.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 public enum GameEvent: Equatable, Sendable {
-    case preloadSong(URL)
     case nextRound
     case roundStarted(RoundData)
     case wrongAnswer

--- a/Models/Sources/Domain/Game/RoundState.swift
+++ b/Models/Sources/Domain/Game/RoundState.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public enum RoundState: Equatable {
     case idle
-    case loading(URL)
+    case loading
     case playing
     case result
     case finished

--- a/Models/Sources/Domain/Music/PreloadSong.swift
+++ b/Models/Sources/Domain/Music/PreloadSong.swift
@@ -1,0 +1,14 @@
+//
+//  PreloadSong.swift
+//  Models
+//
+//  Created by 송지혁 on 5/28/26.
+//
+
+import Foundation
+
+public struct PreloadSong: Equatable, Sendable {
+    public let id: String
+    public let startTime: TimeInterval
+    public let endTime: TimeInterval
+}

--- a/Models/Sources/Domain/Music/PreloadSong.swift
+++ b/Models/Sources/Domain/Music/PreloadSong.swift
@@ -11,4 +11,10 @@ public struct PreloadSong: Equatable, Sendable {
     public let id: String
     public let startTime: TimeInterval
     public let endTime: TimeInterval
+    
+    public init(id: String, startTime: TimeInterval, endTime: TimeInterval) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+    }
 }

--- a/Models/Sources/Domain/Room/RoomEvent.swift
+++ b/Models/Sources/Domain/Room/RoomEvent.swift
@@ -5,6 +5,8 @@
 //  Created by 송지혁 on 5/13/26.
 //
 
+import Foundation
+
 public enum RoomEvent: Equatable {
     case playerJoined(Player)
     case playerLeft(Player)
@@ -13,5 +15,6 @@ public enum RoomEvent: Equatable {
     case roomClosed(RoomCloseReason)
     case gameStarted
     case gameFinished(GameResult)
+    case preloadSong(PreloadSong)
     case game(GameEvent)
 }


### PR DESCRIPTION
## 관련 이슈

closes #24 

## 변경 사항
- preloadSong을 GameEvent에서 RoomEvent로 이동 — RoomReducer가 AudioClient.preload를 직접 호출
- GameReducer에 playMusic / stopMusic delegate action 추가
- roundStarted → playMusic, roundEnded → stopMusic delegate
- RoomReducer에서 delegate 수신 후 AudioClient 호출


## 테스트
개별 테스트: 노래 받기 / 라운드 시작(play) / 라운드 종료(stop)
통합 테스트: 게임 한 사이클 내 preload → play → stop 전체 플로우 검증


## 셀프 체크리스트

- [x] 빌드 성공
- [x] SwiftLint 경고 없음
- [x] 커밋 메시지 컨벤션 준수



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced song preloading with precise timing controls for gameplay rounds.

* **Refactor**
  * Improved audio control architecture during game rounds with ID-based song management.

* **Tests**
  * Added comprehensive test coverage for song preloading and audio playback lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/temp-pj/temp-iOS/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->