### PR TITLE
[Feat] 게임 서버-iOS End-to-End 통합

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,10 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
 
+      - name: Create Secrets.xcconfig
+        run: |
+          mkdir -p Configs
+          echo "SERVER_HOST = ${{ secrets.SERVER_HOST }}" > Configs/Secrets.xcconfig
+
       - name: Run CI
         run: bundle exec fastlane ci

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Temporary Items
 
 ## User settings
 xcuserdata/
+Configs/Secrets.xcconfig
 
 ## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
 *.xcscmblueprint

--- a/Clients/AudioClient/Live/Sources/AudioClient+Live.swift
+++ b/Clients/AudioClient/Live/Sources/AudioClient+Live.swift
@@ -19,8 +19,9 @@ public extension AudioClient {
     static let live: AudioClient = {
         let player = ApplicationMusicPlayer.shared
         
-        return AudioClient { id, start, end in
-            var request = MusicCatalogResourceRequest<Song>(matching: \.id, equalTo: MusicItemID(id))
+        return AudioClient { isrc, start, timeLimit in
+            print("🎵 권한 상태:", MusicAuthorization.currentStatus)
+            var request = MusicCatalogResourceRequest<Song>(matching: \.isrc, equalTo: isrc)
             request.properties = [.albums]
             let response = try await request.response()
             
@@ -28,7 +29,7 @@ public extension AudioClient {
             if songs.isEmpty { throw AudioError.songNotFound }
             guard let song = songs.first else { throw AudioError.songNotFound }
             
-            let entry = MusicPlayer.Queue.Entry(song, startTime: start, endTime: end)
+            let entry = MusicPlayer.Queue.Entry(song, startTime: start, endTime: start + timeLimit)
             player.queue = ApplicationMusicPlayer.Queue([entry])
             
             try await player.prepareToPlay()

--- a/Clients/RoomSessionClient/Interface/Sources/RoomSessionClient.swift
+++ b/Clients/RoomSessionClient/Interface/Sources/RoomSessionClient.swift
@@ -2,12 +2,12 @@ import Foundation
 import Models
 
 public struct RoomSessionClient: Sendable {
-    public var connect: @Sendable (UUID) async throws -> Void
+    public var connect: @Sendable (UUID?) async throws -> Void
     public var send: @Sendable (RoomRequest) async throws -> Void
     public var roomEvents: @Sendable () -> AsyncStream<RoomEvent>
     public var disconnect: @Sendable () async throws -> Void
     
-    public init(connect: @Sendable @escaping (UUID) async throws -> Void,
+    public init(connect: @Sendable @escaping (UUID?) async throws -> Void,
                 send: @Sendable @escaping (RoomRequest) async throws -> Void,
                 roomEvents: @Sendable @escaping () -> AsyncStream<RoomEvent>,
                 disconnect: @Sendable @escaping () async throws -> Void) {

--- a/Clients/RoomSessionClient/Live/Sources/RoomMessageCodec.swift
+++ b/Clients/RoomSessionClient/Live/Sources/RoomMessageCodec.swift
@@ -1,0 +1,118 @@
+//
+//  RoomMessageCodec.swift
+//  ClientRoomSessionLive
+//
+//  Created by 송지혁 on 6/19/26.
+//
+
+import Foundation
+import Models
+
+enum RoomMessageCodecError: Error {
+    case unknownType(String)
+}
+
+public enum RoomMessageCodec {
+    
+    static func encode(_ request: RoomRequest) throws -> Data {
+        switch request {
+            case .game(let gameRequest):
+                switch gameRequest {
+                    case .submitAnswer(let answer):
+                        let payload = SubmitAnswerPayload(answer: answer)
+                        let message = WebSocketMessage<SubmitAnswerPayload>(type: "SUBMIT_ANSWER", payload: payload)
+                        let data = try JSONEncoder().encode(message)
+                        
+                        return data
+                        
+                }
+                
+            case .kickPlayer(let id):
+                let payload = KickPlayerPayload(targetPlayerID: id)
+                let message = WebSocketMessage<KickPlayerPayload>(type: "KICK_PLAYER", payload: payload)
+                let data = try JSONEncoder().encode(message)
+                
+                return data
+                
+            case .readyToPlay(let roundNumber):
+                let payload = ReadyToPlayPayload(roundNumber: roundNumber)
+                let message = WebSocketMessage<ReadyToPlayPayload>(type: "READY_TO_PLAY", payload: payload)
+                let data = try JSONEncoder().encode(message)
+                
+                return data
+                
+            case let .startGame(category, trackCount, timeLimit):
+                let payload = StartGamePayload(category: category, trackCount: trackCount, timeLimit: timeLimit)
+                let message = WebSocketMessage<StartGamePayload>(type: "START_GAME", payload: payload)
+                let data = try JSONEncoder().encode(message)
+                
+                return data
+        }
+    }
+    
+    // 메시지 타입 자체가 많아서 case가 많은거라 린트에서 우려하는 상황이랑 달라서 끔
+    // swiftlint:disable:next cyclomatic_complexity
+    static func decode(_ data: Data, type: String) throws -> RoomEvent? {
+        switch type {
+            case "PLAYER_JOINED":
+                let payload = try JSONDecoder().decode(WebSocketMessage<PlayerJoinedPayload>.self, from: data).payload
+                let player = Player(id: UUID(uuidString: payload.playerID)!)
+                return .playerJoined(player)
+                
+            case "PLAYER_LEFT":
+                let payload = try JSONDecoder().decode(WebSocketMessage<PlayerLeftPayload>.self, from: data).payload
+                let player = Player(id: UUID(uuidString: payload.playerID)!)
+                return .playerLeft(player)
+                
+            case "HOST_CHANGED":
+                let payload = try JSONDecoder().decode(WebSocketMessage<HostChangedPayload>.self, from: data).payload
+                let hostPlayer = Player(id: UUID(uuidString: payload.playerID)!)
+                
+                return .hostChanged(hostPlayer)
+                
+            case "ROUND_STARTED":
+                let payload = try JSONDecoder().decode(WebSocketMessage<RoundStartPayload>.self, from: data).payload
+                let roundData = RoundData(roundNumber: payload.roundNumber,
+                                          totalRounds: payload.totalRounds,
+                                          letterCards: payload.letterCards,
+                                          answerLength: payload.answerLength)
+                
+                return .game(.roundStarted(roundData))
+                
+            case "PRELOAD_SONG":
+                let payload = try JSONDecoder().decode(WebSocketMessage<PreloadSongPayload>.self, from: data).payload
+                
+                return .preloadSong(isrc: payload.isrc, startTime: payload.startTime, roundNumber: payload.roundNumber)
+                
+            case "COUNT_DOWN":
+                let payload = try JSONDecoder().decode(WebSocketMessage<CountDownPayload>.self, from: data).payload
+                
+                return .game(.countDown(payload.remaining))
+                
+            case "WRONG_ANSWER":
+                let payload = try JSONDecoder().decode(WebSocketMessage<WrongAnswerPayload>.self, from: data).payload
+                
+                return .game(.wrongAnswer(playerID: payload.playerID, wrongAnswer: payload.wrongAnswer))
+                
+            case "ROUND_RESULT":
+                let payload = try JSONDecoder().decode(WebSocketMessage<RoundResultPayload>.self, from: data).payload
+                let roundResult = RoundResult(winnerId: payload.winner, correctAnswer: payload.correctAnswer, scores: payload.scores)
+                
+                return .game(.roundEnded(roundResult))
+                
+            case "GAME_OVER":
+                let payload = try JSONDecoder().decode(WebSocketMessage<GameOverPayload>.self, from: data).payload
+                let gameResult = GameResult(winner: payload.winner, scores: payload.scores)
+                
+                return .gameFinished(gameResult)
+                
+            case "GAME_STARTED":
+                return .gameStarted
+                
+            case "PLAYER_KICKED":
+                return .kicked
+                
+            default: return nil
+        }
+    }
+}

--- a/Clients/RoomSessionClient/Live/Sources/RoomSessionClient+Live.swift
+++ b/Clients/RoomSessionClient/Live/Sources/RoomSessionClient+Live.swift
@@ -24,8 +24,7 @@ public extension RoomSessionClient {
             guard let url = URL(string: "wss://\(roomID)") else { throw RoomSessionError.invalidURL  }
             try await webSocketClient.connect(url)
         } send: { request in
-            let message = WebSocketMessage.from(request)
-            let data = try JSONEncoder().encode(message)
+            let data = try RoomMessageCodec.encode(request)
             guard let jsonString = String(data: data, encoding: .utf8) else { throw RoomSessionError.encodingFailed }
             try await webSocketClient.send(jsonString)
             
@@ -35,7 +34,7 @@ public extension RoomSessionClient {
                     for await event in await webSocketClient.receive() {
                         switch event {
                             case .connected:
-                                continuation.yield(.serverConnectionChanged(.connected))
+                                continuation.yield(.serverConnectionChanged(.connecting))
                             case .disconnected(let reason):
                                 switch reason {
                                     case .normal:
@@ -45,13 +44,19 @@ public extension RoomSessionClient {
                                 }
                                 
                             case .message(let rawString):
+                                print("수신된 websocket 메시지: \(rawString)")
                                 if let data = rawString.data(using: .utf8) {
                                     do {
-                                        let message = try JSONDecoder().decode(WebSocketMessage.self, from: data)
-                                        let event = try message.toRoomEvent()
+                                        let type = try JSONDecoder().decode(TypePeek.self, from: data).type
+                                        
+                                        guard let event = try RoomMessageCodec.decode(data, type: type)
+                                                ?? SessionMessageCodec.decode(data, type: type) else { continue }
+                                        
                                         continuation.yield(event)
-                                    } catch { continue }
-                                    
+                                    } catch {
+                                        print("decode 실패: \(error) / 원문: \(rawString)")
+                                        continue
+                                    }
                                 }
                         }
                         

--- a/Clients/RoomSessionClient/Live/Sources/RoomSessionClient+Live.swift
+++ b/Clients/RoomSessionClient/Live/Sources/RoomSessionClient+Live.swift
@@ -21,7 +21,16 @@ public extension RoomSessionClient {
         @Dependency(\.webSocketClient) var webSocketClient
         
         return RoomSessionClient { roomID in
-            guard let url = URL(string: "wss://\(roomID)") else { throw RoomSessionError.invalidURL  }
+            let host = ServerConfig.host
+            
+            let urlString: String
+            if let roomID {
+                urlString = "ws://\(host)/ws?room=\(roomID.uuidString.lowercased())"
+            } else {
+                urlString = "ws://\(host)/ws"
+            }
+            
+            guard let url = URL(string: urlString) else { throw RoomSessionError.invalidURL }
             try await webSocketClient.connect(url)
         } send: { request in
             let data = try RoomMessageCodec.encode(request)

--- a/Clients/RoomSessionClient/Live/Sources/ServerConfig.swift
+++ b/Clients/RoomSessionClient/Live/Sources/ServerConfig.swift
@@ -1,0 +1,18 @@
+//
+//  ServerConfig.swift
+//  ClientRoomSessionLive
+//
+//  Created by 송지혁 on 6/23/26.
+//
+
+import Foundation
+
+enum ServerConfig {
+    static var host: String {
+        guard let host = Bundle.main.object(forInfoDictionaryKey: "SERVER_HOST") as? String, !host.isEmpty else {
+            fatalError("SERVER HOST가 Info.plist에 없음")
+        }
+        
+        return host
+    }
+}

--- a/Clients/RoomSessionClient/Live/Sources/SessionMessageCodec.swift
+++ b/Clients/RoomSessionClient/Live/Sources/SessionMessageCodec.swift
@@ -1,0 +1,36 @@
+//
+//  SessionMessageCodec.swift
+//  Models
+//
+//  Created by 송지혁 on 6/22/26.
+//
+
+import Foundation
+import Models
+
+enum SessionMessageCodecError: Error {
+    case unknownType(String)
+}
+
+public enum SessionMessageCodec {
+    static func decode(_ data: Data, type: String) throws -> RoomEvent? {
+        
+        switch type {
+            case "WELCOME":
+                let payload = try JSONDecoder().decode(WebSocketMessage<WelcomePayload>.self, from: data).payload
+                
+                let players = payload.players.map { Player(id: UUID(uuidString: $0)!) }
+                
+                let roomConnectionInfo = RoomConnectionInfo(myPlayerID: payload.playerID,
+                                                            roomID: payload.roomID,
+                                                            hostID: payload.hostID,
+                                                            roomState: payload.roomState,
+                                                            players: players,
+                                                            maxPlayers: payload.maxPlayers)
+                
+                return .serverConnectionChanged(.connected(roomConnectionInfo))
+                
+            default: return nil
+        }
+    }
+}

--- a/Clients/RoomSessionClient/Live/Sources/TypePeek.swift
+++ b/Clients/RoomSessionClient/Live/Sources/TypePeek.swift
@@ -1,0 +1,10 @@
+//
+//  TypePeek.swift
+//  Models
+//
+//  Created by 송지혁 on 6/22/26.
+//
+
+internal struct TypePeek: Decodable {
+    let type: String
+    }

--- a/Clients/RoomSessionClient/Test/Sources/RoomSessionClient+Test.swift
+++ b/Clients/RoomSessionClient/Test/Sources/RoomSessionClient+Test.swift
@@ -12,7 +12,7 @@ import Models
 
 public extension RoomSessionClient {
     static func mock(
-    connect: @escaping @Sendable (UUID) async throws -> Void = { _ in },
+    connect: @escaping @Sendable (UUID?) async throws -> Void = { _ in },
     send: @escaping @Sendable (RoomRequest) async throws -> Void = { _ in },
     roomEvents: @escaping @Sendable () -> AsyncStream<RoomEvent> = { .finished },
     disconnect: @escaping @Sendable () async throws -> Void = { }

--- a/Features/Room/Sources/Game/GameReducer.swift
+++ b/Features/Room/Sources/Game/GameReducer.swift
@@ -15,6 +15,7 @@ public struct GameReducer {
         public var inputState: InputState = .enabled
         public var roundData: RoundData?
         public var roundResult: RoundResult?
+        public var remainingTime = 0
     }
     
     public enum Action {
@@ -94,6 +95,11 @@ public struct GameReducer {
                             state.inputState = .enabled
                             state.roundState = .idle
                             state.selectedLetters = []
+                            
+                            return .none
+                        
+                        case .countDown(let remaining):
+                            state.remainingTime = remaining
                             
                             return .none
                     }

--- a/Features/Room/Sources/Game/GameReducer.swift
+++ b/Features/Room/Sources/Game/GameReducer.swift
@@ -43,9 +43,9 @@ public struct GameReducer {
             switch action {
                 case .selectLetter(let index):
                     guard state.inputState == .enabled else { return .none }
-                    guard let roundData = state.roundData, index >= 0, index < roundData.wordCards.count,
+                    guard let roundData = state.roundData, index >= 0, index < roundData.letterCards.count,
                             state.selectedLetters.count < roundData.answerLength else { return .none }
-                    let letter = roundData.wordCards[index]
+                    let letter = roundData.letterCards[index]
                     state.selectedLetters.append(letter)
                     
                     if state.selectedLetters.count == roundData.answerLength {

--- a/Features/Room/Sources/Room/RoomReducer.swift
+++ b/Features/Room/Sources/Room/RoomReducer.swift
@@ -14,13 +14,13 @@ import Models
 @Reducer
 public struct RoomReducer {
     public typealias PlayerID = UUID
-    public typealias RoomID = UUID
+    public typealias RoomID = String
     
     public init() { }
     
     @ObservableState
     public struct State: Equatable {
-        public let roomID: RoomID
+        public var roomID: RoomID
         public var hostID: PlayerID
         public var players: [PlayerID: Player]
         public var roomState: RoomSessionState = .waiting

--- a/Features/Room/Sources/Room/RoomReducer.swift
+++ b/Features/Room/Sources/Room/RoomReducer.swift
@@ -23,6 +23,7 @@ public struct RoomReducer {
         public var roomID: RoomID
         public var hostID: PlayerID
         public var players: [PlayerID: Player]
+        public var maxPlayers: Int = 8
         public var roomState: RoomSessionState = .waiting
         public var gameState: GameReducer.State?
         public var gameResult: GameResult?
@@ -90,9 +91,21 @@ public struct RoomReducer {
                             
                         case .serverConnectionChanged(let connectionState):
                             state.serverConnectionState = connectionState
+                            
+                            if case .connected(let roomConnectionInfo) = connectionState {
+                                state.roomID = roomConnectionInfo.roomID
+                                state.hostID = UUID(uuidString: roomConnectionInfo.hostID)!
+                                state.roomState = RoomSessionState(rawValue: roomConnectionInfo.roomState) ?? .waiting
+                                state.players = roomConnectionInfo.players.reduce(into: [:]) { dict, player in
+                                    dict[player.id] = player
+                                }
+                                state.maxPlayers = roomConnectionInfo.maxPlayers
+                                                                
+                            }
+                            
                             return .none
                             
-                        case .roomClosed(let reason):
+                        case .kicked:
                             return .none
                             
                         case .preloadSong(let song):
@@ -100,7 +113,7 @@ public struct RoomReducer {
                                 // 추후에 여기서 startTime < endTime 방어 로직 구현
                                 try await audioClient.preload(song.id, song.startTime, song.endTime)
                             }
-                            
+                    
                         case .game(let event):
                             return .send(.game(.serverEvent(event)))
                             

--- a/Features/Room/Sources/Room/RoomReducer.swift
+++ b/Features/Room/Sources/Room/RoomReducer.swift
@@ -22,6 +22,7 @@ public struct RoomReducer {
     public struct State: Equatable {
         public var roomID: RoomID
         public var hostID: PlayerID
+        public var timeLimit: Int = 30
         public var players: [PlayerID: Player]
         public var maxPlayers: Int = 8
         public var roomState: RoomSessionState = .waiting
@@ -108,10 +109,12 @@ public struct RoomReducer {
                         case .kicked:
                             return .none
                             
-                        case .preloadSong(let song):
-                            return .run { _ in
-                                // 추후에 여기서 startTime < endTime 방어 로직 구현
-                                try await audioClient.preload(song.id, song.startTime, song.endTime)
+                        case .preloadSong(let isrc, let startTime, let roundNumber):
+                            let timeLimit = TimeInterval(state.timeLimit)
+                            
+                            return .run { send in
+                                try await audioClient.preload(isrc, TimeInterval(startTime), timeLimit)
+                                await send(.toServer(.readyToPlay(roundNumber)))
                             }
                     
                         case .game(let event):

--- a/Features/Room/Sources/Room/RoomView.swift
+++ b/Features/Room/Sources/Room/RoomView.swift
@@ -1,0 +1,97 @@
+//
+//  RoomView.swift
+//  FeatureRoom
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+import ComposableArchitecture
+import Models
+import SwiftUI
+
+public struct RoomView: View {
+    public let store: StoreOf<RoomReducer>
+    private let columns = [GridItem(.adaptive(minimum: 56), spacing: 10)]
+    
+    public init(store: StoreOf<RoomReducer>) {
+        self.store = store
+    }
+    
+    public var body: some View {
+        VStack {
+            Text("ROOMID: \(store.roomID)\n")
+            Text("Players: \(store.players.keys.debugDescription)\n")
+            Text("RoomState: \(store.roomState)\n")
+            Text("MAXPLAYER: \(store.maxPlayers)\n")
+            Text("HostID: \(store.hostID)\n")
+            Text("serverConnectionState: \(store.serverConnectionState)\n")
+            Text("GameResult: \(store.gameResult)\n")
+            
+            if let gameStore = store.scope(state: \.gameState, action: \.game) {
+                
+                HStack {
+                    Image(systemName: "clock.fill")
+                        .foregroundColor(gameStore.remainingTime <= 5 ? .red : .orange)
+                    
+                    Text("\(gameStore.remainingTime)초")
+                        .font(.title)
+                        .monospacedDigit()
+                        .fontWeight(.bold)
+                        .foregroundColor(gameStore.remainingTime <= 5 ? .red : .primary)
+                }
+                .padding(.bottom, 10)
+                .animation(.default, value: gameStore.remainingTime)
+                
+                Text(gameStore.selectedLetters.joined())
+                    .bold()
+                
+                let cards = gameStore.roundData?.letterCards ?? []
+                
+                if cards.isEmpty {
+                    Text("카드를 불러오는 중이거나 없습니다... 👾")
+                        .foregroundColor(.gray)
+                        .padding()
+                } else {
+                    LazyVGrid(columns: columns, spacing: 10) {
+                        ForEach(Array(cards.enumerated()), id: \.offset) { index, letter in
+                            Button {
+                                gameStore.send(.selectLetter(index))
+                            } label: {
+                                Text(letter)
+                                    .font(.title2)
+                                    .fontWeight(.bold)
+                                    .frame(width: 48, height: 48)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(Color.orange, lineWidth: 2)
+                                    )
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                    .id(cards.joined())
+                }
+                
+                Button("SUBMIT") {
+                    gameStore.send(.submit(gameStore.selectedLetters.joined()))
+                }
+                
+            } else {
+                Text("게임 시작을 기다리는 중... ⏱️")
+                    .foregroundColor(.secondary)
+                    .padding()
+            }
+            
+            Button("GAME START") {
+                store.send(.toServer(.startGame(category: Category(startYear: 2010,
+                                                                   endYear: 2020,
+                                                                   artistType: "Person",
+                                                                   country: "South Korea",
+                                                                   gender: "Male",
+                                                                   genre: "ballad"),
+                                                trackCount: 3, timeLimit: store.timeLimit)))
+            }
+        }
+        .onAppear { store.send(.onAppear) }
+    }
+}

--- a/Features/Room/Tests/GameReducerTests.swift
+++ b/Features/Room/Tests/GameReducerTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class GameReducerTests: XCTestCase {
     
     func test_answerLength_도달_시_자동_제출() async {
-        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만"], answerLength: 3, timeLimit: 10000)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, letterCards: ["그", "대", "만"], answerLength: 3)
         let store = await TestStore(initialState: GameReducer.State(roundData: roundData), reducer: { GameReducer() })
         
         await store.send(.selectLetter(0)) {
@@ -39,7 +39,7 @@ final class GameReducerTests: XCTestCase {
     }
     
     func test_answerLength_초과_입력_무시() async {
-        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만"], answerLength: 3, timeLimit: 10000)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, letterCards: ["그", "대", "만"], answerLength: 3)
         let store = await TestStore(
             initialState: GameReducer.State(selectedLetters: ["그", "대", "만"], roundData: roundData),
             reducer: { GameReducer() }
@@ -49,7 +49,7 @@ final class GameReducerTests: XCTestCase {
     }
     
     func test_inputState_penalized_일_때_selectLetter() async {
-        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만"], answerLength: 3, timeLimit: 10000)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, letterCards: ["그", "대", "만"], answerLength: 3)
         
         let store = await TestStore(
             initialState: GameReducer.State(inputState: .penalized, roundData: roundData),
@@ -60,7 +60,7 @@ final class GameReducerTests: XCTestCase {
     }
     
     func test_inputState_submitting_일_떄_selectLetter() async {
-        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만"], answerLength: 3, timeLimit: 10000)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, letterCards: ["그", "대", "만"], answerLength: 3)
         
         let store = await TestStore(
             initialState: GameReducer.State(inputState: .submitting, roundData: roundData),

--- a/Features/Room/Tests/Mocks/RoomTestMocks.swift
+++ b/Features/Room/Tests/Mocks/RoomTestMocks.swift
@@ -12,8 +12,7 @@ extension RoundData {
     static func mock(roundNumber: Int, totalRounds: Int, wordCards: [String], answerLength: Int, timeLimit: TimeInterval) -> RoundData {
         return RoundData(roundNumber: roundNumber,
                          totalRounds: totalRounds,
-                         wordCards: wordCards,
-                         answerLength: answerLength,
-                         timeLimit: timeLimit)
+                         letterCards: wordCards,
+                         answerLength: answerLength)
     }
 }

--- a/Features/Room/Tests/RoomReducerTests.swift
+++ b/Features/Room/Tests/RoomReducerTests.swift
@@ -29,7 +29,7 @@ final class RoomReducerTests: XCTestCase {
         var didPlay = false
         var didStop = false
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID",
                                                                     hostID: hostPlayer.id,
                                                                     players: [hostPlayer.id: hostPlayer],
                                                                     roomState: .waiting),
@@ -81,10 +81,11 @@ final class RoomReducerTests: XCTestCase {
         }
         
         // preload Song
-        let songID = "1675478652"
-        continuation.yield(.preloadSong(PreloadSong(id: songID, startTime: 0, endTime: 30)))
+        let isrc = "1675478652"
+        continuation.yield(.preloadSong(isrc: isrc, startTime: 0, roundNumber: 30))
         
         await store.receive(\.receive)
+        await store.receive(\.toServer) 
         
         // 라운드 시작
         let roundData = RoundData.mock(roundNumber: 1, totalRounds: 100, wordCards: ["그", "대", "만", "있", "다", "면", "마", "라", "탕"], answerLength: 6, timeLimit: 3600)
@@ -110,7 +111,7 @@ final class RoomReducerTests: XCTestCase {
         XCTAssertEqual(request, .game(.submitAnswer(wrongAnswer.joined())))
         
         // 오답 패널티
-        continuation.yield(.game(.wrongAnswer))
+        continuation.yield(.game(.wrongAnswer(playerID: player1.id.uuidString, wrongAnswer: wrongAnswer.joined())))
         await store.receive(\.receive)
         await store.receive(\.game) {
             $0.gameState?.inputState = .penalized
@@ -125,7 +126,7 @@ final class RoomReducerTests: XCTestCase {
         
         // 라운드 종료(정답 or 시간 초과)
         
-        let roundResult = RoundResult(winnerId: player2.id, correctAnswer: "그대만 있다면", scores: [:])
+        let roundResult = RoundResult(winnerId: player2.id.uuidString, correctAnswer: "그대만 있다면", scores: [:])
         
         continuation.yield(.game(.roundEnded(roundResult)))
         
@@ -151,7 +152,7 @@ final class RoomReducerTests: XCTestCase {
         }
         
         // 게임 종료
-        let gameResult = GameResult()
+        let gameResult = GameResult(winner: "WINNER_ID", scores: [:])
         continuation.yield(.gameFinished(gameResult))
         
         await store.receive(\.receive) {
@@ -168,7 +169,7 @@ final class RoomReducerTests: XCTestCase {
         
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: UUID(), players: [:])) {
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID", hostID: UUID(), players: [:])) {
             RoomReducer()
         } withDependencies: {
             $0.roomSessionClient = .mock(roomEvents: { stream })
@@ -191,7 +192,7 @@ final class RoomReducerTests: XCTestCase {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         let player = Player(id: UUID())
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: UUID(), players: [player.id: player]), reducer: { RoomReducer() }) {
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID", hostID: UUID(), players: [player.id: player]), reducer: { RoomReducer() }) {
             $0.roomSessionClient = .mock(roomEvents: { stream })
         }
         
@@ -212,7 +213,7 @@ final class RoomReducerTests: XCTestCase {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         let hostPlayer = Player(id: UUID())
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: hostPlayer.id, players: [:]), reducer: { RoomReducer() }) {
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID", hostID: hostPlayer.id, players: [:]), reducer: { RoomReducer() }) {
             $0.roomSessionClient = .mock(roomEvents: { stream })
         }
         
@@ -235,7 +236,7 @@ final class RoomReducerTests: XCTestCase {
     func test_게임_시작() async {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: UUID(), players: [:])) {
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID", hostID: UUID(), players: [:])) {
             RoomReducer()
         } withDependencies: { $0.roomSessionClient = .mock(roomEvents: { stream }) }
         
@@ -257,7 +258,7 @@ final class RoomReducerTests: XCTestCase {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         var fetchedID: String?
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(), hostID: UUID(), players: [:], gameState: GameReducer.State())) {
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID", hostID: UUID(), players: [:], gameState: GameReducer.State())) {
             RoomReducer()
         } withDependencies: {
             $0.roomSessionClient = .mock(roomEvents: { stream })
@@ -267,10 +268,11 @@ final class RoomReducerTests: XCTestCase {
         await store.send(.onAppear)
         
         // 에픽하이 - 우산
-        continuation.yield(.preloadSong(PreloadSong(id: "1675478652", startTime: 0, endTime: 30)))
+        continuation.yield(.preloadSong(isrc: "TEST_ISRC", startTime: 0, roundNumber: 1))
         
         await store.receive(\.receive)
-        XCTAssertEqual(fetchedID, "1675478652")
+        XCTAssertEqual(fetchedID, "TEST_ISRC")
+        await store.receive(\.toServer)
         
         continuation.finish()
         await store.send(.onDisappear)
@@ -278,10 +280,10 @@ final class RoomReducerTests: XCTestCase {
     
     func test_라운드_시작() async {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
-        let roundData = RoundData(roundNumber: 1, totalRounds: 100, wordCards: ["타", "임", "캡", "슐"], answerLength: 4, timeLimit: 1000)
+        let roundData = RoundData(roundNumber: 1, totalRounds: 100, letterCards: ["타", "임", "캡", "슐"], answerLength: 4)
         var didPlay = false
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID",
                                                                     hostID: UUID(),
                                                                     players: [:],
                                                                     roomState: .playing,
@@ -312,10 +314,10 @@ final class RoomReducerTests: XCTestCase {
     
     func test_라운드_종료() async {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
-        let roundResult = RoundResult(winnerId: UUID(), correctAnswer: "편지", scores: [:])
+        let roundResult = RoundResult(winnerId: "WINNER_ID", correctAnswer: "편지", scores: [:])
         var didStop = false
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID",
                                                                     hostID: UUID(),
                                                                     players: [:],
                                                                     roomState: .playing,
@@ -347,7 +349,7 @@ final class RoomReducerTests: XCTestCase {
     func test_게임_종료() async {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID",
                                                                     hostID: UUID(),
                                                                     players: [:],
                                                                     roomState: .playing,
@@ -356,7 +358,7 @@ final class RoomReducerTests: XCTestCase {
         }
         
         await store.send(.onAppear)
-        let gameResult = GameResult()
+        let gameResult = GameResult(winner: "WINNER_ID", scores: [:])
         continuation.yield(.gameFinished(gameResult))
         
         await store.receive(\.receive) {
@@ -374,7 +376,7 @@ final class RoomReducerTests: XCTestCase {
         let (stream, continuation) = AsyncStream.makeStream(of: RoomEvent.self)
         var sentRequest: RoomRequest?
         
-        let store = await TestStore(initialState: RoomReducer.State(roomID: UUID(),
+        let store = await TestStore(initialState: RoomReducer.State(roomID: "TEST_ROOM_ID",
                                                                     hostID: UUID(),
                                                                     players: [:],
                                                                     roomState: .playing,

--- a/M_GAME/Sources/AppFeature.swift
+++ b/M_GAME/Sources/AppFeature.swift
@@ -7,23 +7,57 @@
 
 import ComposableArchitecture
 import FeatureLogin
+import FeatureRoom
+import Foundation
 
 @Reducer
 struct AppFeature {
     @ObservableState
     struct State {
+        var room: RoomReducer.State?
         
     }
     
     enum Action {
+        case room(RoomReducer.Action)
+        case onAppear
+        case joinRoomTapped(String)
+        case createRoomSuccess(String)
         
     }
     
+    @Dependency(\.roomSessionClient) var roomSessionClient
+    @Dependency(\.musicEntitlementClient) var musicEntitlementClient
+    
     var body: some ReducerOf<Self> {
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
-                default: return .none
+                    
+                case .onAppear:
+                    return .run { _ in
+                        await musicEntitlementClient.requestAuthorization()
+                    }
+                    
+                case .joinRoomTapped(let id):
+                    return .run { send in
+                        if id.isEmpty {
+                            try await roomSessionClient.connect(nil)
+                        } else {
+                            try await roomSessionClient.connect(UUID(uuidString: id))
+                        }
+                        
+                        await send(.createRoomSuccess(id))
+                    }
+                    
+                case .createRoomSuccess(let id):
+                    state.room = RoomReducer.State(roomID: id, hostID: UUID(), players: [:])
+                    return .none
+                    
+                case .room: return .none
             }
+        }
+        .ifLet(\.room, action: \.room) {
+            RoomReducer()
         }
     }
 }

--- a/M_GAME/Sources/ContentView.swift
+++ b/M_GAME/Sources/ContentView.swift
@@ -1,12 +1,25 @@
 import ComposableArchitecture
+import FeatureRoom
 import SwiftUI
 
 struct ContentView: View {
     let store: StoreOf<AppFeature>
+    @State private var roomID = ""
     
     var body: some View {
-        Text("Hello, World!")
-            .padding()
+        VStack {
+            if let roomStore = store.scope(state: \.room, action: \.room) {
+                RoomView(store: roomStore)
+            } else {
+                
+                TextField("방 아이디", text: $roomID)
+                Button("방 입장") {
+                    store.send(.joinRoomTapped(roomID))
+                }
+            }
+        }
+        .padding()
+        .onAppear { store.send(.onAppear) }
     }
 }
 

--- a/M_GAME/Sources/MGAMEApp.swift
+++ b/M_GAME/Sources/MGAMEApp.swift
@@ -3,6 +3,7 @@ import ClientAuthLive
 import ClientRoomSessionLive
 import ClientMusicEntitlementLive
 import ClientRoomLive
+import ClientWebSocketLive
 import ComposableArchitecture
 import FeatureRoom
 import Foundation
@@ -18,6 +19,7 @@ struct MGAMEApp: App {
         $0.roomClient = .live
         $0.roomSessionClient = .live
         $0.audioClient = .live
+        $0.webSocketClient = .live
     }
     
     var body: some Scene {

--- a/Models/Sources/DTO/Websocket/Payload/CountDownPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/CountDownPayload.swift
@@ -1,0 +1,10 @@
+//
+//  CountDownPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct CountDownPayload: Codable {
+    public let remaining: Int
+}

--- a/Models/Sources/DTO/Websocket/Payload/GameOverPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/GameOverPayload.swift
@@ -1,0 +1,11 @@
+//
+//  GameOverPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct GameOverPayload: Codable {
+    public let winner: String
+    public let scores: [String: Int]
+}

--- a/Models/Sources/DTO/Websocket/Payload/HostChangedPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/HostChangedPayload.swift
@@ -1,0 +1,10 @@
+//
+//  HostChangedPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct HostChangedPayload: Codable {
+    public let playerID: String
+}

--- a/Models/Sources/DTO/Websocket/Payload/KickPlayerPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/KickPlayerPayload.swift
@@ -5,12 +5,10 @@
 //  Created by 송지혁 on 5/14/26.
 //
 
-import Foundation
-
 public struct KickPlayerPayload: Codable {
-    let playerId: UUID
+    let targetPlayerID: String
     
-    enum CodingKeys: String, CodingKey {
-        case playerId = "player_id"
+    public init(targetPlayerID: String) {
+        self.targetPlayerID = targetPlayerID
     }
 }

--- a/Models/Sources/DTO/Websocket/Payload/PlayerJoinedPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/PlayerJoinedPayload.swift
@@ -1,0 +1,10 @@
+//
+//  PlayerJoinedPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct PlayerJoinedPayload: Codable {
+    public let playerID: String
+}

--- a/Models/Sources/DTO/Websocket/Payload/PlayerLeftPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/PlayerLeftPayload.swift
@@ -1,0 +1,10 @@
+//
+//  PlayerLeftPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct PlayerLeftPayload: Codable {
+    public let playerID: String
+}

--- a/Models/Sources/DTO/Websocket/Payload/PreloadSongPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/PreloadSongPayload.swift
@@ -1,0 +1,12 @@
+//
+//  PreloadSongPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/2/26.
+//
+
+public struct PreloadSongPayload: Codable {
+    public let isrc: String
+    public let startTime: Int
+    public let roundNumber: Int
+}

--- a/Models/Sources/DTO/Websocket/Payload/ReadyToPlayPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/ReadyToPlayPayload.swift
@@ -1,0 +1,14 @@
+//
+//  ReadyToPlayPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct ReadyToPlayPayload: Codable {
+    let roundNumber: Int
+    
+    public init(roundNumber: Int) {
+        self.roundNumber = roundNumber
+    }
+}

--- a/Models/Sources/DTO/Websocket/Payload/RoundResultPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/RoundResultPayload.swift
@@ -1,0 +1,12 @@
+//
+//  RoundResultPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct RoundResultPayload: Codable {
+    public let winner: String
+    public let correctAnswer: String
+    public let scores: [String: Int]
+}

--- a/Models/Sources/DTO/Websocket/Payload/RoundStartPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/RoundStartPayload.swift
@@ -1,13 +1,13 @@
 //
-//  RoundData.swift
+//  RoundStartPayload.swift
 //  Models
 //
-//  Created by 송지혁 on 5/3/26.
+//  Created by 송지혁 on 6/4/26.
 //
 
 import Foundation
 
-public struct RoundData: Equatable, Sendable, Decodable {
+public struct RoundStartPayload: Codable {
     public let roundNumber: Int
     public let totalRounds: Int
     public let answerLength: Int

--- a/Models/Sources/DTO/Websocket/Payload/StartGamePayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/StartGamePayload.swift
@@ -1,0 +1,18 @@
+//
+//  StartGamePayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/2/26.
+//
+
+public struct StartGamePayload: Codable {
+    let category: Category
+    let trackCount: Int
+    let timeLimit: Int
+    
+    public init(category: Category, trackCount: Int, timeLimit: Int) {
+        self.category = category
+        self.trackCount = trackCount
+        self.timeLimit = timeLimit
+    }
+}

--- a/Models/Sources/DTO/Websocket/Payload/SubmitAnswerPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/SubmitAnswerPayload.swift
@@ -7,4 +7,8 @@
 
 public struct SubmitAnswerPayload: Codable {
     let answer: String
+    
+    public init(answer: String) {
+        self.answer = answer
+    }
 }

--- a/Models/Sources/DTO/Websocket/Payload/WelcomePayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/WelcomePayload.swift
@@ -1,0 +1,15 @@
+//
+//  WelcomePayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/22/26.
+//
+
+public struct WelcomePayload: Codable {
+    public let hostID: String
+    public let roomID: String
+    public let playerID: String
+    public let players: [String]
+    public let roomState: String
+    public let maxPlayers: Int
+}

--- a/Models/Sources/DTO/Websocket/Payload/WrongAnswerPayload.swift
+++ b/Models/Sources/DTO/Websocket/Payload/WrongAnswerPayload.swift
@@ -1,0 +1,11 @@
+//
+//  WrongAnswerPayload.swift
+//  Models
+//
+//  Created by 송지혁 on 6/4/26.
+//
+
+public struct WrongAnswerPayload: Codable {
+    public let playerID: String
+    public let wrongAnswer: String
+}

--- a/Models/Sources/DTO/Websocket/WebSocketMessage.swift
+++ b/Models/Sources/DTO/Websocket/WebSocketMessage.swift
@@ -11,63 +11,12 @@ public enum WebSocketError: Error {
     case unknownType(String)
 }
 
-public struct WebSocketMessage: Codable {
-    let type: String
-    let payload: Data
-}
-
-public extension WebSocketMessage {
-    static func from(_ request: RoomRequest) -> WebSocketMessage {
-        switch request {
-            case .startGame:
-                return WebSocketMessage(type: "START_GAME",
-                                        payload: Data())
-                
-            case .kickPlayer(let playerId):
-                let payload = KickPlayerPayload(playerId: playerId)
-                let payloadData = try! JSONEncoder().encode(payload)
-                return WebSocketMessage(type: "KICK_PLAYER", payload: payloadData)
-                
-            case .game(.submitAnswer(let answer)):
-                let payload = SubmitAnswerPayload(answer: answer)
-                let payloadData = try! JSONEncoder().encode(payload)
-                return WebSocketMessage(type: "SUBMIT_ANSWER", payload: payloadData)
-        }
-    }
-}
-
-public extension WebSocketMessage {
-    func toRoomEvent() throws -> RoomEvent {
-        switch self.type {
-            case "PLAYER_JOINED":
-                let player = try JSONDecoder().decode(Player.self, from: self.payload)
-                return .playerJoined(player)
-                
-            case "PLAYER_LEFT":
-                let player = try JSONDecoder().decode(Player.self, from: self.payload)
-                return .playerLeft(player)
-                
-            case "HOST_CHANGED":
-                let player = try JSONDecoder().decode(Player.self, from: self.payload)
-                return .hostChanged(player)
-                
-            case "ROOM_CLOSED":
-                let reason = try JSONDecoder().decode(RoomCloseReason.self, from: self.payload)
-                return .roomClosed(reason)
-                
-            case "ROUND_STARTED":
-                let data = try JSONDecoder().decode(RoundData.self, from: self.payload)
-                return .game(.roundStarted(data))
-            
-            case "WRONG_ANSWER":
-                return .game(.wrongAnswer)
-                
-            case "ROUND_ENDED":
-                let result = try JSONDecoder().decode(RoundResult.self, from: self.payload)
-                return .game(.roundEnded(result))
-                
-            default: throw WebSocketError.unknownType(self.type)
-        }
-        
+public struct WebSocketMessage<Payload: Codable>: Codable {
+    public let type: String
+    public let payload: Payload
+    
+    public init(type: String, payload: Payload) {
+        self.type = type
+        self.payload = payload
     }
 }

--- a/Models/Sources/Domain/Game/GameEvent.swift
+++ b/Models/Sources/Domain/Game/GameEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 public enum GameEvent: Equatable, Sendable {
     case nextRound
     case roundStarted(RoundData)
-    case wrongAnswer
+    case countDown(Int)
+    case wrongAnswer(playerID: String, wrongAnswer: String)
     case roundEnded(RoundResult)
 }

--- a/Models/Sources/Domain/Game/GameResult.swift
+++ b/Models/Sources/Domain/Game/GameResult.swift
@@ -6,5 +6,11 @@
 //
 
 public struct GameResult: Equatable, Sendable, Decodable {
-    public init() { }
+    public let winner: String
+    public let scores: [String: Int]
+    
+    public init(winner: String, scores: [String: Int]) {
+        self.winner = winner
+        self.scores = scores
+    }
 }

--- a/Models/Sources/Domain/Game/RoundResult.swift
+++ b/Models/Sources/Domain/Game/RoundResult.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-public struct RoundResult: Equatable, Sendable, Decodable {
-    public let winnerId: UUID?
+public struct RoundResult: Equatable, Sendable, Codable {
+    public let winnerId: String?
     public let correctAnswer: String
-    public let scores: [UUID: Int]
+    public let scores: [String: Int]
     
-    public init(winnerId: UUID?, correctAnswer: String, scores: [UUID: Int]) {
+    public init(winnerId: String?, correctAnswer: String, scores: [String: Int]) {
         self.winnerId = winnerId
         self.correctAnswer = correctAnswer
         self.scores = scores

--- a/Models/Sources/Domain/Music/Category.swift
+++ b/Models/Sources/Domain/Music/Category.swift
@@ -1,0 +1,26 @@
+//
+//  Category.swift
+//  Models
+//
+//  Created by 송지혁 on 6/2/26.
+//
+
+import Foundation
+
+public struct Category: Equatable, Codable {
+    let startYear: Int
+    let endYear: Int
+    let artistType: String
+    let country: String
+    let gender: String
+    let genre: String
+    
+    public init(startYear: Int, endYear: Int, artistType: String, country: String, gender: String, genre: String) {
+        self.startYear = startYear
+        self.endYear = endYear
+        self.artistType = artistType
+        self.country = country
+        self.gender = gender
+        self.genre = genre
+    }
+}

--- a/Models/Sources/Domain/Music/PreloadSong.swift
+++ b/Models/Sources/Domain/Music/PreloadSong.swift
@@ -8,13 +8,11 @@
 import Foundation
 
 public struct PreloadSong: Equatable, Sendable {
-    public let id: String
+    public let isrc: String
     public let startTime: TimeInterval
-    public let endTime: TimeInterval
     
-    public init(id: String, startTime: TimeInterval, endTime: TimeInterval) {
-        self.id = id
+    public init(isrc: String, startTime: TimeInterval) {
+        self.isrc = isrc
         self.startTime = startTime
-        self.endTime = endTime
     }
 }

--- a/Models/Sources/Domain/Room/RoomConnectionInfo.swift
+++ b/Models/Sources/Domain/Room/RoomConnectionInfo.swift
@@ -1,0 +1,24 @@
+//
+//  RoomConnectionInfo.swift
+//  Models
+//
+//  Created by 송지혁 on 6/22/26.
+//
+
+public struct RoomConnectionInfo: Equatable {
+    public let myPlayerID: String
+    public let roomID: String
+    public let hostID: String
+    public let roomState: String
+    public let players: [Player]
+    public let maxPlayers: Int
+    
+    public init(myPlayerID: String, roomID: String, hostID: String, roomState: String, players: [Player], maxPlayers: Int) {
+        self.myPlayerID = myPlayerID
+        self.roomID = roomID
+        self.hostID = hostID
+        self.roomState = roomState
+        self.players = players
+        self.maxPlayers = maxPlayers
+    }
+}

--- a/Models/Sources/Domain/Room/RoomEvent.swift
+++ b/Models/Sources/Domain/Room/RoomEvent.swift
@@ -11,10 +11,10 @@ public enum RoomEvent: Equatable {
     case playerJoined(Player)
     case playerLeft(Player)
     case hostChanged(Player)
+    case kicked
     case serverConnectionChanged(ServerConnectionState)
-    case roomClosed(RoomCloseReason)
     case gameStarted
     case gameFinished(GameResult)
-    case preloadSong(PreloadSong)
+    case preloadSong(isrc: String, startTime: Int, roundNumber: Int)
     case game(GameEvent)
 }

--- a/Models/Sources/Domain/Room/RoomRequest.swift
+++ b/Models/Sources/Domain/Room/RoomRequest.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
-public typealias PlayerID = UUID
+public typealias PlayerID = String
 
 public enum RoomRequest: Equatable {
-    case startGame
+    case startGame(category: Category, trackCount: Int, timeLimit: Int)
+    case readyToPlay(Int)
     case kickPlayer(PlayerID)
     case game(GameRequest)
 }

--- a/Models/Sources/Domain/Room/RoomSessionState.swift
+++ b/Models/Sources/Domain/Room/RoomSessionState.swift
@@ -5,7 +5,7 @@
 //  Created by 송지혁 on 5/13/26.
 //
 
-public enum RoomSessionState: Equatable {
+public enum RoomSessionState: String, Equatable {
     case waiting
     case playing
     case result

--- a/Models/Sources/Domain/Room/ServerConnectionState.swift
+++ b/Models/Sources/Domain/Room/ServerConnectionState.swift
@@ -7,7 +7,7 @@
 
 public enum ServerConnectionState: Equatable {
     case connecting
-    case connected
+    case connected(RoomConnectionInfo)
     case reconnecting
     case disconnected(DisconnectReason)
 }

--- a/Project.swift
+++ b/Project.swift
@@ -307,7 +307,11 @@ let project = Project(
                             "UIColorName": "",
                             "UIImageName": "",
                         ],
-                        "NSAppleMusicUsageDescription": "음악 퀴즈를 위해 Apple Music 접근이 필요합니다."
+                        "NSAppleMusicUsageDescription": "음악 퀴즈를 위해 Apple Music 접근이 필요합니다.",
+                        "NSAppTransportSecurity": [
+                            "NSAllowsArbitraryLoads": true
+                        ],
+                        "SERVER_HOST": "$(SERVER_HOST)"
                     ]
                 ),
                 sources: ["M_GAME/Sources/**"],
@@ -323,7 +327,13 @@ let project = Project(
                     .target(name: "ClientRoomSessionLive"),
                     .target(name: "ClientWebSocketLive"),
                     .external(name: "ComposableArchitecture")
-                ]
+                ],
+                settings: .settings(
+                    configurations: [
+                        .debug(name: "Debug", xcconfig: "Configs/Secrets.xcconfig"),
+                        .release(name: "Release", xcconfig: "Configs/Secrets.xcconfig"),
+                    ]
+                    )
             ),
     ]
 )


### PR DESCRIPTION
## 개요
서버 Game 엔진과 iOS 클라이언트를 연결해, 게임 한 판의 전체 사이클이
실기기에서 끊김 없이 동작하는 것을 확인

Closes #26 

## 작업 내용

### 1. API Contract 대조
- 서버 `payloads.go`의 메시지 타입/payload와 iOS Swift 구조체 대조
- 누락·불일치 필드 수정 (camelCase 키 정렬로 별도 CodingKeys 제거)

### 2. 게임 플로우 연결
- `START_GAME` 전송 → `GAME_STARTED` 수신
- `PRELOAD_SONG` 수신 → ISRC로 Apple Music 조회 후 프리로드
- `READY_TO_PLAY` 전송 → `ROUND_START` 수신
- `ROUND_START` 수신 시 음악 재생 + 글자 카드 표시 + 카운트다운 시작
- `COUNTDOWN` 수신 → 타이머 UI 동기화
- `SUBMIT_ANSWER` 전송 → `WRONG_ANSWER` / `ROUND_RESULT` 수신
- `ROUND_RESULT` 수신 → 결과 표시 후 다음 라운드 프리로드
- 마지막 라운드 후 `GAME_OVER` 수신 → 최종 결과 화면

### 3. 테스트
- 실기기 2대에서 전체 사이클 동작 확인

## 동작 확인
- [x] 게임 시작 → 라운드 진행 → 답 제출 → 점수 반영 → 게임 종료까지 전체 사이클 동작
- [x] COUNTDOWN이 양쪽 기기에서 동기화 표시


## 동영상

https://github.com/user-attachments/assets/785b144f-590f-4623-b0ab-1e4a40305d01



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a room lobby and in-game screen, including room details, player list, countdown timer, letter selection, and game start controls.
  * Added support for joining a room from the app’s main screen.
  * Expanded live game updates to show round starts, countdowns, results, and player join/leave activity.

* **Bug Fixes**
  * Improved track loading and room connection behavior for more reliable gameplay.
  * Updated configuration handling so app secrets and server settings are ignored from source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->